### PR TITLE
Restructure root-signing ownership

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -903,7 +903,10 @@ repositories:
     teams:
       - name: sigstore-keyholders
         id: 4899309
-        permission: admin
+        permission: write
+      - name: tuf-root-signing-codeowners
+        id: 4899309
+        permission: maintain
       - name: triage
         id: 5643322
         permission: triage

--- a/github-sync/github-data/teams.yaml
+++ b/github-sync/github-data/teams.yaml
@@ -56,6 +56,9 @@ teams:
   - name: rekor-operator-team
     privacy: closed
     description: ""
+  - name: tuf-root-signing-codeowners
+    privacy: closed
+    description: ""
   - name: scaffolding-codeowners
     privacy: closed
     description: maintainers on sigstore/scaffolding

--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -34,7 +34,7 @@ users:
         role: member
       - name: sget-codeowners
         role: member
-      - name: sigstore-keyholders
+      - name: tuf-root-signing-codeowners
         role: member
   - username: bobcallaway
     role: admin
@@ -66,6 +66,8 @@ users:
       - name: security-response-team
         role: maintainer
       - name: public-good-instance-team
+        role: maintainer
+      - name: tuf-root-signing-codeowners
         role: maintainer
   - username: caniszczyk
     role: admin
@@ -133,6 +135,8 @@ users:
         role: maintainer
       - name: triage
         role: maintainer
+      - name: tuf-root-signing-codeowners
+        role: maintainer
   - username: efebarlas
     role: member
     teams:
@@ -168,6 +172,8 @@ users:
       - name: architecture-doc-team
         role: member
       - name: fulcio-codeowners
+        role: member
+      - name: tuf-root-signing-codeowners
         role: member
   - username: hectorj2f
     role: member
@@ -276,6 +282,8 @@ users:
       - name: sigstore-release-team
         role: maintainer
       - name: sigstore-rs-codeowners
+        role: maintainer
+      - name: tuf-root-signing-codeowners
         role: maintainer
       - name: codeowners-k8s-manifest-sigstore
         role: maintainer


### PR DESCRIPTION
Change:

* Changed sigstore-keyholders to write. admin granted too much power,
  and maintain granted the ability to modify the repo settings which
  didn't seem necessary.

No effective change, but just restructuring:

* Added a codeowners group, maintained by the TSC
* asraa and haydentherapper in the codeowners group
* codeowners given maintain over root-signing

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->