### PR TITLE
Set workflow to use pull_request_target and add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+#
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "./github-sync"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10

--- a/.github/workflows/github-sync-pr.yml
+++ b/.github/workflows/github-sync-pr.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
       - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # v3
         with:
           go-version: 1.18

--- a/.github/workflows/github-sync-pr.yml
+++ b/.github/workflows/github-sync-pr.yml
@@ -1,7 +1,7 @@
 name: Preview changes to GitHub configuration on Pull Request
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'github-sync/github-data/*.yaml'
       - 'github-sync/main.go'
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # v3
         with:
           go-version: 1.18


### PR DESCRIPTION
#### Summary
- Set workflow to use pull_request_target
this is needed to run the workflow for forks PRs (for example https://github.com/sigstore/community/pull/68) also to reduce any possible issue, i've set the action to be approved to all PRs is coming from non org members

- add dependabot config


#### Release Note

`n/a`

#### Documentation

`n/a`