### PR TITLE
add sigstore-bot to policy-controller repo to be able to push releases

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -657,6 +657,8 @@ repositories:
         permission: maintain
       - username: vaikas
         permission: admin
+      - username: sigstore-bot
+        permission: push
     branchesProtection:
       - pattern: main
         dismissStaleReviews: true


### PR DESCRIPTION

#### Summary
- add sigstore-bot to policy-controller repo to be able to push releases

similar config we have with cosign/rekor/fulcio repos

#### Release Note

`n/a`

#### Documentation

`n/a`