### PR TITLE
add new repo to hold the github-sync code and actions

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -400,6 +400,33 @@ repositories:
           - fulcio-codeowners
         dismissalRestrictions:
           - fulcio-codeowners
+  - name: github-sync
+    owner: sigstore
+    description: Pulumi GitHub Sync for sigstore
+    homepageUrl: https://sigstore.dev
+    allowAutoMerge: true
+    allowMergeCommit: true
+    allowRebaseMerge: true
+    allowSquashMerge: true
+    archived: false
+    autoInit: false
+    deleteBranchOnMerge: true
+    hasDownloads: true
+    hasIssues: true
+    hasProjects: false
+    hasWiki: false
+    vulnerabilityAlerts: true
+    visibility: public
+    licenseTemplate: ""
+    topics:
+      - sigstore
+      - automation
+      - pulumi
+    collaborators:
+      - username: bobcallaway
+        permission: admin
+      - username: cpanato
+        permission: admin
   - name: gitsign
     owner: sigstore
     description: Keyless Git signing using Sigstore


### PR DESCRIPTION
#### Summary
- add new repo to hold the github-sync code and actions

As discussed with @bobcallaway we are requesting a new repository to hold the github-sync code to remove the code dependency from the community repository, also we will create an reusable action in the new repo  that will be used here to run the github-sync, and in the community repo will contain only the data and not more the code.



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->