### PR TITLE
import sigstore-js to sigstore org

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -1320,6 +1320,49 @@ repositories:
           - gha-oidc-tests (11)
           - build (17)
           - build (11)
+  - name: sigstore-js
+    owner: sigstore
+    description: Code-signing for npm packages
+    homepageUrl: ""
+    allowAutoMerge: true
+    allowMergeCommit: true
+    allowRebaseMerge: true
+    allowSquashMerge: true
+    archived: false
+    autoInit: false
+    deleteBranchOnMerge: true
+    hasDownloads: true
+    hasIssues: true
+    hasProjects: true
+    hasWiki: false
+    vulnerabilityAlerts: true
+    visibility: public
+    licenseTemplate: ""
+    topics:
+      - javascript
+      - node
+      - security
+      - supply-chain
+      - codesigning
+    collaborators:
+      - username: bdehamer
+        permission: admin
+    teams:
+      - name: Core Team
+        id: 4563391
+        permission: pull
+      - name: codeowners-sigstore-js
+        id: 6411558
+        permission: pull
+    branchesProtection:
+      - pattern: main
+        requiredLinearHistory: true
+        dismissStaleReviews: true
+        requiredApprovingReviewCount: 1
+        requireCodeOwnerReviews: true
+        requireBranchesUpToDate: true
+        statusChecks:
+          - DCO
   - name: sigstore-maven
     owner: sigstore
     description: sigstore maven plugin

--- a/github-sync/github-data/teams.yaml
+++ b/github-sync/github-data/teams.yaml
@@ -14,6 +14,9 @@ teams:
   - name: codeowners-ruby-sigstore
     privacy: closed
     description: ""
+  - name: codeowners-sigstore-js
+    privacy: closed
+    description: sigstore-js maintainers
   - name: codeowners-sigstore-python
     privacy: closed
     description: sigstore-python maintainers

--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -36,6 +36,11 @@ users:
         role: member
       - name: tuf-root-signing-codeowners
         role: member
+  - username: bdehamer
+    role: member
+    teams:
+      - name: sigstore-js-codeowners
+        role: maintainer
   - username: bobcallaway
     role: admin
     teams:


### PR DESCRIPTION
#### Summary
import the `sigstore-js` into pulumi infra and add the config in the yaml

This is just to sync the data, it was applied manually during the import phase.

xref: https://github.com/sigstore/community/pull/81

cc @bdehamer 