### PR TITLE
add new sigstore-js maintainers

### DIFF
--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -142,6 +142,11 @@ users:
         role: maintainer
       - name: tuf-root-signing-codeowners
         role: maintainer
+  - username: eddiezane
+    role: member
+    teams:
+      - name: codeowners-sigstore-js
+        role: maintainer
   - username: efebarlas
     role: member
     teams:
@@ -157,6 +162,11 @@ users:
     teams:
       - name: codeowners-sigstore-website
         role: member
+  - username: feelepxyz
+    role: member
+    teams:
+      - name: codeowners-sigstore-js
+        role: maintainer
   - username: flavio
     role: member
     teams:


### PR DESCRIPTION
#### Summary
Adds two new maintainers to the `codeowners-sigstore-js` team:

* @eddiezane (Chainguard)
* @feelepxyz (GitHub)

ref: https://github.com/sigstore/community/pull/87

cc @bdehamer 