### PR TITLE
Try to fix public-good-instance permissions bug

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -755,7 +755,7 @@ repositories:
     topics: []
     collaborators:
       - username: afeddersen
-        permission: pull
+        permission: maintain
       - username: asraa
         permission: triage
       - username: bobcallaway
@@ -786,12 +786,11 @@ repositories:
         permission: pull
       - username: strongjz
         permission: triage
+      - username: vaikas
+        permission: maintain
       - username: var-sdk
         permission: maintain
     teams:
-      - name: public-good-instance-team
-        id: 5623385
-        permission: triage
       - name: triage
         id: 5643322
         permission: triage


### PR DESCRIPTION
I lost write access to public-good-instance, as did Kenny (https://github.com/sigstore/public-good-instance/pull/501)

The `public-good-instance-team` team perms were just changed from `push` to `triage`, and I'm wondering if that's overriding the individual collaborator perms. I'm not totally sure where this team is defined anyway or what it's used for, so I want to try removing it to see it fixes the bug.

Also gives oncall members maintainer permissions.

If anyone knows more about how this works let me know, I'm just trying stuff out to see if it fixes this.