### PR TITLE
sync users for public-instance repo

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -795,6 +795,9 @@ repositories:
       - username: var-sdk
         permission: maintain
     teams:
+      - name: public-good-instance-team
+        id: 5623385
+        permission: triage
       - name: triage
         id: 5643322
         permission: triage

--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -786,6 +786,10 @@ repositories:
         permission: pull
       - username: strongjz
         permission: triage
+      - username: trevrosen
+        permission: pull
+      - username: trixor
+        permission: triage
       - username: vaikas
         permission: maintain
       - username: var-sdk

--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -755,7 +755,7 @@ repositories:
     topics: []
     collaborators:
       - username: afeddersen
-        permission: maintain
+        permission: triage
       - username: asraa
         permission: triage
       - username: bobcallaway


### PR DESCRIPTION
#### Summary
- sync users for public-instance repo
looks like we had some users that was not in the file

- add back public-good-instance-team
- update `afeddersen` permission to triage