### PR TITLE
update status check for cosign and scaffold repo

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -142,7 +142,23 @@ repositories:
         requiredApprovingReviewCount: 1
         requireCodeOwnerReviews: true
         statusChecks:
+          - Check Whitespace
           - DCO
+          - Do Not Submit
+          - Run PowerShell E2E tests
+          - Run e2e tests
+          - Run unit tests (macos-latest)
+          - Run unit tests (ubuntu-latest)
+          - Run unit tests (windows-latest)
+          - Verify Docgen
+          - build (macos-latest)
+          - build (ubuntu-latest)
+          - build (windows-latest)
+          - dependency-review
+          - license boilerplate check
+          - lint
+          - validate-release-job
+          - attest / verify-attestation test (v1.24.x)
         pushRestrictions:
           - cosign-codeowners
   - name: cosign-gatekeeper-provider

--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -1078,10 +1078,29 @@ repositories:
         requiredApprovingReviewCount: 1
         requireCodeOwnerReviews: true
         statusChecks:
-          - license boilerplate check
-          - DCO
           - Analyze (go)
+          - Analyze (go)
+          - CodeQL
+          - DCO
           - Shellcheck
+          - license boilerplate check
+          - e2e tests (v1.22.x, fulcio rekor ctlog e2e, true, 1.18)
+          - e2e tests (v1.22.x, fulcio rekor ctlog e2e, false, 1.18)
+          - e2e tests (v1.23.x, fulcio rekor ctlog e2e, false, 1.18)
+          - e2e tests (v1.23.x, fulcio rekor ctlog e2e, true, 1.18)
+          - e2e tests (v1.24.x, fulcio rekor ctlog e2e, true, 1.18)
+          - e2e tests (v1.24.x, fulcio rekor ctlog e2e, false, 1.18)
+          - e2e tests using release (v1.22.x, fulcio rekor ctlog e2e, 1.18)
+          - e2e tests using release (v1.23.x, fulcio rekor ctlog e2e, 1.18)
+          - e2e tests using release (v1.24.x, fulcio rekor ctlog e2e, 1.18)
+          - Test github action (v1.22.x, v0.3.0, 1.18, test github action)
+          - Test github action (v1.22.x, v0.4.3, 1.18, test github action)
+          - Test github action with TUF (v1.22.x, latest-release, 1.18, test github action with TUF)
+          - Test github action with TUF (v1.23.x, latest-release, 1.18, test github action with TUF)
+          - Test github action with TUF (v1.24.x, latest-release, 1.18, test github action with TUF)
+          - Test github action with TUF (v1.22.x, v0.4.2, 1.18, test github action with TUF)
+          - Test github action with TUF (v1.23.x, v0.4.2, 1.18, test github action with TUF)
+          - Test github action with TUF (v1.24.x, v0.4.2, 1.18, test github action with TUF)
         pushRestrictions:
           - scaffolding-codeowners
   - name: sget


### PR DESCRIPTION
#### Summary
- update status check for cosign and scaffold repo, now all existing jobs are required 

this is already applied, just to sync with the code automation

Fixes: https://github.com/sigstore/cosign/issues/2154 
Fixes: https://github.com/sigstore/scaffolding/issues/289

### For cosign:

![Screenshot 2022-08-16 at 10 14 08](https://user-images.githubusercontent.com/4115580/184831347-dab950d2-c1c3-415c-8692-a71b15ab4961.png)
![Screenshot 2022-08-16 at 10 14 00](https://user-images.githubusercontent.com/4115580/184831354-a92c4378-f8bb-4ed2-a734-b2b2c217558e.png)

### for scaffold

![Screenshot 2022-08-16 at 10 42 18](https://user-images.githubusercontent.com/4115580/184836936-a86728b0-60d0-4dd3-a079-25c773a27dde.png)

