### PR TITLE
add gitsign-codeowners team to gitsign repo

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -514,6 +514,10 @@ repositories:
         permission: maintain
       - username: wlynch
         permission: admin
+    teams:
+      - name: gitsign-codeowners
+        id: 6463637
+        permission: maintain
     branchesProtection:
       - pattern: main
         enforceAdmins: true


### PR DESCRIPTION
#### Summary
- add gitsign-codeowners team to gitsign repo

the team and users were created/added here #98, now adding the team in the repository 

cc @wlynch 