### PR TITLE
Add GH Pkg Sec team members

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -798,6 +798,8 @@ repositories:
         permission: admin
       - username: chainguardian
         permission: pull
+      - username: codysoyland
+        permission: triage
       - username: cpanato
         permission: admin
       - username: dekkagaijin
@@ -810,6 +812,8 @@ repositories:
         permission: maintain
       - username: loosebazooka
         permission: pull
+      - username: malancas
+        permission: triage
       - username: mattmoor
         permission: pull
       - username: nsmith5
@@ -817,6 +821,8 @@ repositories:
       - username: priyawadhwa
         permission: maintain
       - username: puerco
+        permission: triage
+      - username: pwelch
         permission: triage
       - username: sabre1041
         permission: pull

--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -84,7 +84,9 @@ users:
         role: member
   - username: codysoyland
     role: member
-    teams: []
+    teams:
+      - name: triage
+        role: member
   - username: coyote240
     role: member
     teams: []
@@ -160,6 +162,11 @@ users:
     teams:
       - name: rekor-monitor-codeowners
         role: member
+  - username: ejahngithub
+    role: member
+    teams:
+      - name: codeowners-sigstore-js
+        role: maintainer
   - username: endorama
     role: member
     teams:
@@ -324,7 +331,9 @@ users:
         role: maintainer
   - username: malancas
     role: member
-    teams: []
+    teams:
+      - name: triage
+        role: member
   - username: mattmoor
     role: member
     teams:
@@ -385,7 +394,9 @@ users:
         role: member
   - username: pwelch
     role: member
-    teams: []
+    teams:
+      - name: triage
+        role: member
   - username: sabre1041
     role: member
     teams:
@@ -398,7 +409,9 @@ users:
     teams: []
   - username: trevrosen
     role: member
-    teams: []
+    teams:
+      - name: triage
+        role: member
   - username: vaikas
     role: member
     teams:

--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -82,6 +82,9 @@ users:
     teams:
       - name: public-good-instance-team
         role: member
+  - username: codysoyland
+    role: member
+    teams: []
   - username: coyote240
     role: member
     teams: []
@@ -319,6 +322,9 @@ users:
         role: maintainer
       - name: cosign-codeowners
         role: maintainer
+  - username: malancas
+    role: member
+    teams: []
   - username: mattmoor
     role: member
     teams:
@@ -377,6 +383,9 @@ users:
     teams:
       - name: triage
         role: member
+  - username: pwelch
+    role: member
+    teams: []
   - username: sabre1041
     role: member
     teams:
@@ -386,6 +395,9 @@ users:
         role: member
   - username: thelinuxfoundation
     role: admin
+    teams: []
+  - username: trevrosen
+    role: member
     teams: []
   - username: vaikas
     role: member

--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -10,7 +10,7 @@ users:
       - name: cosign-codeowners
         role: member
   - username: SantiagoTorres
-    role: member
+    role: admin
     teams:
       - name: rekor-monitor-codeowners
         role: member
@@ -84,9 +84,7 @@ users:
         role: member
   - username: codysoyland
     role: member
-    teams:
-      - name: triage
-        role: member
+    teams: []
   - username: coyote240
     role: member
     teams: []
@@ -331,9 +329,7 @@ users:
         role: maintainer
   - username: malancas
     role: member
-    teams:
-      - name: triage
-        role: member
+    teams: []
   - username: mattmoor
     role: member
     teams:
@@ -394,9 +390,7 @@ users:
         role: member
   - username: pwelch
     role: member
-    teams:
-      - name: triage
-        role: member
+    teams: []
   - username: sabre1041
     role: member
     teams:
@@ -408,7 +402,7 @@ users:
     role: admin
     teams: []
   - username: trevrosen
-    role: member
+    role: admin
     teams:
       - name: triage
         role: member


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Adds three GitHub employees from the Package Security team to the organization so they can participate in on-call and issue triage:

* Meredith Lancaster (@malancas)
* Cody Soyland (@codysoyland)
* Paul Welch (@pwelch)

Adds GitHub employee Eugene Jahn (@ejahngithub) to maintainers for sigstore-js

Also adds me (@trevrosen) to the YAML - I believe someone established my existing membership through the web UI.


#### Release Note
NONE

#### Documentation
NONE