### PR TITLE
Move caniszczyk to "member"

### DIFF
--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -75,7 +75,7 @@ users:
       - name: tuf-root-signing-codeowners
         role: maintainer
   - username: caniszczyk
-    role: admin
+    role: member
     teams: []
   - username: cdris
     role: member


### PR DESCRIPTION
**Note:** we can close this if the below justification for removal is erroneous and my feelings won't be hurt!

Removes `admin` rights for @caniszczyk since the `linuxfoundation` account also has `admin`



Signed-off-by: Trevor Rosen <trevrosen@github.com>