### PR TITLE
Add var-sdk to as a triage member

### DIFF
--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -396,6 +396,11 @@ users:
         role: member
       - name: cosign-codeowners
         role: member
+  - username: var-sdk
+    role: member
+    teams:
+      - name: triage
+        role: member
   - username: yuji-watanabe-jp
     role: member
     teams:


### PR DESCRIPTION
#### Summary
- Add var-sdk to as a triage member 

from: https://github.com/sigstore/community/pull/103

