### PR TITLE
sync trevrosen and SantiagoTorres to the core team

### DIFF
--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -16,6 +16,8 @@ users:
         role: member
       - name: sigstore-keyholders
         role: member
+      - name: Core Team
+        role: maintainer
   - username: ariel-kirson
     role: member
     teams:
@@ -405,7 +407,9 @@ users:
     role: admin
     teams:
       - name: triage
-        role: member
+        role: maintainer
+      - name: Core Team
+        role: maintainer
   - username: vaikas
     role: member
     teams:


### PR DESCRIPTION
#### Summary
- sync `trevrosen` and `SantiagoTorres` to the core team

the New TSC members were already in the team, but not in the config. so syncing it.
