### PR TITLE
remove users and add teams to rekor-monitor project

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -922,17 +922,14 @@ repositories:
     visibility: public
     licenseTemplate: ""
     topics: []
-    collaborators:
-      - username: SantiagoTorres
-        permission: admin
-      - username: hojoung97
-        permission: push
-      - username: jehanshah8
-        permission: push
+    collaborators: []
     teams:
       - name: rekor-monitor-codeowners
         id: 4722221
-        permission: push
+        permission: maintain
+      - name: triage
+        id: 5643322
+        permission: triage
     branchesProtection:
       - pattern: main
         enforceAdmins: false


### PR DESCRIPTION
#### Summary
- remove users and add teams to rekor-monitor project

split https://github.com/sigstore/community/pull/110 to test the new actions
