### PR TITLE
Update rekor-monitor codeowners

### DIFF
--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -1,9 +1,6 @@
 users:
   - username: A0su
     role: member
-    teams:
-      - name: rekor-monitor-codeowners
-        role: member
   - username: Dentrax
     role: member
     teams:
@@ -36,6 +33,8 @@ users:
         role: member
       - name: sget-codeowners
         role: member
+      - name: rekor-monitor-codeowners
+        role: maintainer
       - name: tuf-root-signing-codeowners
         role: member
   - username: bdehamer
@@ -67,6 +66,8 @@ users:
       - name: policy-controller-codeowners
         role: maintainer
       - name: rekor-codeowners
+        role: maintainer
+      - name: rekor-monitor-codeowners
         role: maintainer
       - name: scaffolding-codeowners
         role: maintainer
@@ -159,9 +160,6 @@ users:
         role: maintainer
   - username: efebarlas
     role: member
-    teams:
-      - name: rekor-monitor-codeowners
-        role: member
   - username: ejahngithub
     role: member
     teams:
@@ -203,6 +201,8 @@ users:
         role: member
       - name: fulcio-codeowners
         role: member
+      - name: rekor-monitor-codeowners
+        role: maintainer
       - name: tuf-root-signing-codeowners
         role: member
   - username: hectorj2f


### PR DESCRIPTION
#### Summary
- Removed users who are no longer active on project and update the team

second part of #110 and https://github.com/sigstore/community/pull/109

