### PR TITLE
create new repo to host the tools and services used in sigstore

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -1223,6 +1223,43 @@ repositories:
           - sigstore-codeowners
         dismissalRestrictions:
           - sigstore-codeowners
+  - name: sigstore-devops-tools
+    owner: sigstore
+    description: Tools & services used to help in the development flow of sigstore
+    homepageUrl: https://sigstore.dev
+    allowAutoMerge: true
+    allowMergeCommit: true
+    allowRebaseMerge: true
+    allowSquashMerge: true
+    archived: false
+    autoInit: false
+    deleteBranchOnMerge: true
+    hasDownloads: true
+    hasIssues: true
+    hasProjects: false
+    hasWiki: false
+    vulnerabilityAlerts: true
+    visibility: public
+    licenseTemplate: ""
+    template:
+      owner: sigstore
+      repository: sigstore-project-template
+    topics:
+      - sigstore
+      - automation
+      - devops
+      - tools
+    collaborators:
+      - username: bobcallaway
+        permission: admin
+      - username: cpanato
+        permission: admin
+    branchesProtection:
+      - pattern: main
+        dismissStaleReviews: true
+        requiredApprovingReviewCount: 1
+        statusChecks:
+          - DCO
   - name: sigstore-git-verifier
     owner: sigstore
     description: A Github Action to verify that new commits are present in the sigstore transparency log.


### PR DESCRIPTION

#### Summary
 - create new repo to host the tools and services used in sigstore

spoke with Bob before and the idea of this repository is to host the tools and services that will support the development of the sigstore tools & services

for example:

- this will will have a small function to check who is on-call for sigstore
- will have the github webhook function to work with release notes (see https://sigstore.slack.com/archives/C01DGF0G8U9/p1662017529021859)
