### PR TITLE
disable required signed commits for sigstore-rs

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -1569,7 +1569,7 @@ repositories:
     branchesProtection:
       - pattern: main
         allowsDeletions: true
-        requireSignedCommits: true
+        requireSignedCommits: false
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
         requireCodeOwnerReviews: true


### PR DESCRIPTION
#### Summary
- disable required signed commits for sigstore-rs

in my case, for example, I use gitsign to sign the commits, but GitHub does not validate that.

