### PR TITLE
adding thomas (@tstromberg) to the sigstore org

### DIFF
--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -413,6 +413,8 @@ users:
         role: maintainer
       - name: Core Team
         role: maintainer
+  - username: tstromberg
+    role: member
   - username: vaikas
     role: member
     teams:


### PR DESCRIPTION
#### Summary
- adding Thomas (@tstromberg) to the sigstore org

He is part of the sigstore on-call team and will need access to some
repositories