### PR TITLE
Give oncall write access to helm-charts, p-g-i, and scaffolding

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -579,6 +579,9 @@ repositories:
       - name: helm
         id: 5291354
         permission: admin
+      - name: sigstore-oncall
+        id: 6693572
+        permission: write
     branchesProtection:
       - pattern: main
         dismissStaleReviews: true
@@ -849,6 +852,9 @@ repositories:
       - name: triage
         id: 5643322
         permission: triage
+      - name: sigstore-oncall
+        id: 6693572
+        permission: write
     branchesProtection:
       - pattern: main
         dismissStaleReviews: true
@@ -1099,6 +1105,9 @@ repositories:
       - name: scaffolding-codeowners
         id: 5757921
         permission: admin
+      - name: sigstore-oncall
+        id: 6693572
+        permission: write
     branchesProtection:
       - pattern: main
         enforceAdmins: true

--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -77,8 +77,6 @@ users:
         role: maintainer
       - name: tuf-root-signing-codeowners
         role: maintainer
-      - name: sigstore-oncall
-        role: member
   - username: caniszczyk
     role: member
     teams: []
@@ -335,8 +333,6 @@ users:
         role: maintainer
       - name: cosign-codeowners
         role: maintainer
-      - name: sigstore-oncall
-        role: member
   - username: malancas
     role: member
     teams: []
@@ -401,8 +397,6 @@ users:
       - name: rekor-codeowners
         role: member
       - name: triage
-        role: member
-      - name: sigstore-oncall
         role: member
       - name: Core Team
         role: maintainer


### PR DESCRIPTION
ref https://github.com/sigstore/public-good-instance/issues/646

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->