### PR TITLE
Update GitHub staff timestamp-authority perms

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -1741,10 +1741,12 @@ repositories:
     licenseTemplate: ""
     topics: []
     collaborators:
-      - username: malancas
+      - username: codysoyland
         permission: maintain
       - username: haydentherapper
         permission: admin
+      - username: malancas
+        permission: maintain
     teams:
       - name: timestamp-codeowners
         id: 6735686

--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -1742,7 +1742,7 @@ repositories:
     topics: []
     collaborators:
       - username: malancas
-        permission: triage
+        permission: maintain
       - username: haydentherapper
         permission: admin
     teams:


### PR DESCRIPTION
## What
Adds @malancas and @codysoyland to the timestamp-authority repo as maintainers.

## Why
They're going to be doing a lot of work on this repo and I want things to go quickly. Previously @malancas had `triage` and @codysoyland had no perms.
