### PR TITLE
Remove requiring codeowner for rekor-monitor/tsa

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -996,7 +996,7 @@ repositories:
         allowsForcePushes: false
         requiredLinearHistory: true
         requiredApprovingReviewCount: 1
-        requireCodeOwnerReviews: true
+        requireCodeOwnerReviews: false
         restrictDismissals: true
         requireBranchesUpToDate: false
         dismissStaleReviews: true
@@ -1759,7 +1759,7 @@ repositories:
         allowsForcePushes: false
         requiredLinearHistory: true
         requiredApprovingReviewCount: 1
-        requireCodeOwnerReviews: true
+        requireCodeOwnerReviews: false
         restrictDismissals: true
         requireBranchesUpToDate: false
         dismissStaleReviews: true


### PR DESCRIPTION
I don't find this necessary, and it makes it hard to LGTM dependabot.

Signed-off-by: Hayden B <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->