### PR TITLE
Added new repository: protobuf-specs

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -1770,3 +1770,48 @@ repositories:
           - timestamp-codeowners
         dismissalRestrictions:
           - timestamp-codeowners
+  - name: protobuf-specs
+    owner: sigstore
+    description: Protocol Buffer specifications
+    homepageUrl: ""
+    allowAutoMerge: false
+    allowMergeCommit: false
+    allowRebaseMerge: true
+    allowSquashMerge: true
+    archived: false
+    autoInit: false
+    deleteBranchOnMerge: true
+    hasDownloads: true
+    hasIssues: true
+    hasProjects: true
+    hasWiki: true
+    vulnerabilityAlerts: true
+    visibility: public
+    licenseTemplate: ""
+    topics: []
+    collaborators:
+      - username: znewman01
+        permission: admin
+      - username: haydentherapper
+        permission: admin
+      - username: kommendorkapten
+        permission: maintain
+    teams:
+      - name: Core Team
+        id: 4563391
+        permission: maintain
+    branchesProtection:
+      - pattern: main
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
+        requiredLinearHistory: true
+        requiredApprovingReviewCount: 1
+        requireCodeOwnerReviews: false
+        restrictDismissals: true
+        requireBranchesUpToDate: false
+        dismissStaleReviews: true
+        statusChecks:
+          - DCO
+#        pushRestrictions:
+#        dismissalRestrictions:

--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -873,10 +873,10 @@ repositories:
         dismissStaleReviews: true
         statusChecks:
           - DCO
-        pushRestrictions:
-          - protobuf-specs-codeowners
-        dismissalRestrictions:
-          - protobuf-specs-codeowners
+        # pushRestrictions:
+        #   - protobuf-specs-codeowners
+        # dismissalRestrictions:
+        #   - protobuf-specs-codeowners
   - name: public-good-instance
     owner: sigstore
     description: ""

--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -857,9 +857,9 @@ repositories:
       - name: Core Team
         id: 4563391
         permission: maintain
-      # - name: protobuf-specs-codeowners
-      #   id:
-      #   permission: maintain
+      - name: protobuf-specs-codeowners
+        id: 6829685
+        permission: maintain
     branchesProtection:
       - pattern: main
         enforceAdmins: true

--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -873,10 +873,10 @@ repositories:
         dismissStaleReviews: true
         statusChecks:
           - DCO
-        # pushRestrictions:
-        #   - protobuf-specs-codeowners
-        # dismissalRestrictions:
-        #   - protobuf-specs-codeowners
+        pushRestrictions:
+          - protobuf-specs-codeowners
+        dismissalRestrictions:
+          - protobuf-specs-codeowners
   - name: public-good-instance
     owner: sigstore
     description: ""

--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -825,6 +825,58 @@ repositories:
           - ClusterImagePolicy e2e tests (v1.24.x, cluster_image_policy)
           - ClusterImagePolicy e2e tests (v1.24.x, cluster_with_scalable)
           - ClusterImagePolicy e2e tests (v1.24.x, cluster_image_policy_with_attestations)
+  - name: protobuf-specs
+    owner: sigstore
+    description: Protocol Buffer specifications
+    homepageUrl: ""
+    allowAutoMerge: false
+    allowMergeCommit: false
+    allowRebaseMerge: true
+    allowSquashMerge: true
+    archived: false
+    autoInit: false
+    deleteBranchOnMerge: true
+    hasDownloads: true
+    hasIssues: true
+    hasProjects: true
+    hasWiki: true
+    vulnerabilityAlerts: true
+    visibility: public
+    licenseTemplate: ""
+    topics: []
+    collaborators:
+      - username: asraa
+        permission: admin
+      - username: haydentherapper
+        permission: admin
+      - username: kommendorkapten
+        permission: maintain
+      - username: znewman01
+        permission: admin
+    teams:
+      - name: Core Team
+        id: 4563391
+        permission: maintain
+      # - name: protobuf-specs-codeowners
+      #   id:
+      #   permission: maintain
+    branchesProtection:
+      - pattern: main
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
+        requiredLinearHistory: true
+        requiredApprovingReviewCount: 1
+        requireCodeOwnerReviews: false
+        restrictDismissals: true
+        requireBranchesUpToDate: false
+        dismissStaleReviews: true
+        statusChecks:
+          - DCO
+        pushRestrictions:
+          - protobuf-specs-codeowners
+        dismissalRestrictions:
+          - protobuf-specs-codeowners
   - name: public-good-instance
     owner: sigstore
     description: ""
@@ -1770,48 +1822,3 @@ repositories:
           - timestamp-codeowners
         dismissalRestrictions:
           - timestamp-codeowners
-  - name: protobuf-specs
-    owner: sigstore
-    description: Protocol Buffer specifications
-    homepageUrl: ""
-    allowAutoMerge: false
-    allowMergeCommit: false
-    allowRebaseMerge: true
-    allowSquashMerge: true
-    archived: false
-    autoInit: false
-    deleteBranchOnMerge: true
-    hasDownloads: true
-    hasIssues: true
-    hasProjects: true
-    hasWiki: true
-    vulnerabilityAlerts: true
-    visibility: public
-    licenseTemplate: ""
-    topics: []
-    collaborators:
-      - username: znewman01
-        permission: admin
-      - username: haydentherapper
-        permission: admin
-      - username: kommendorkapten
-        permission: maintain
-    teams:
-      - name: Core Team
-        id: 4563391
-        permission: maintain
-    branchesProtection:
-      - pattern: main
-        enforceAdmins: true
-        allowsDeletions: false
-        allowsForcePushes: false
-        requiredLinearHistory: true
-        requiredApprovingReviewCount: 1
-        requireCodeOwnerReviews: false
-        restrictDismissals: true
-        requireBranchesUpToDate: false
-        dismissStaleReviews: true
-        statusChecks:
-          - DCO
-#        pushRestrictions:
-#        dismissalRestrictions:

--- a/github-sync/github-data/teams.yaml
+++ b/github-sync/github-data/teams.yaml
@@ -50,6 +50,9 @@ teams:
   - name: policy-controller-codeowners
     privacy: closed
     description: Codeowners for sigstore/policy-controller
+  - name: protobuf-specs-codeowners
+    privacy: closed
+    description: "Code owners for protobuf specifications"
   - name: public-good-instance-team
     privacy: secret
     description: those with access to configuration of the public good service

--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -39,8 +39,8 @@ users:
         role: maintainer
       - name: timestamp-codeowners
         role: member
-      # - name: protobuf-specs-codeowners
-      #   role: member
+      - name: protobuf-specs-codeowners
+        role: member
   - username: bdehamer
     role: member
     teams:
@@ -69,8 +69,8 @@ users:
         role: maintainer
       - name: policy-controller-codeowners
         role: maintainer
-      # - name: protobuf-specs-codeowners
-      #   role: member
+      - name: protobuf-specs-codeowners
+        role: member
       - name: rekor-codeowners
         role: maintainer
       - name: rekor-monitor-codeowners
@@ -219,8 +219,8 @@ users:
         role: maintainer
       - name: timestamp-codeowners
         role: member
-      # - name: protobuf-specs-codeowners
-      #   role: member
+      - name: protobuf-specs-codeowners
+        role: member
   - username: hectorj2f
     role: member
     teams:
@@ -277,8 +277,8 @@ users:
   - username: kommendorkapten
     role: member
     teams: []
-      # - name: protobuf-specs-codeowners
-      #   role: member
+      - name: protobuf-specs-codeowners
+        role: member
   - username: lkatalin
     role: member
     teams:
@@ -494,5 +494,5 @@ users:
         role: member
       - name: cosign-codeowners
         role: member
-      # - name: protobuf-specs-codeowners
-      #   role: member
+      - name: protobuf-specs-codeowners
+        role: member

--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -39,6 +39,8 @@ users:
         role: maintainer
       - name: timestamp-codeowners
         role: member
+      - name: protobuf-specs-codeowners
+        role: member
   - username: bdehamer
     role: member
     teams:
@@ -67,6 +69,8 @@ users:
         role: maintainer
       - name: policy-controller-codeowners
         role: maintainer
+      - name: protobuf-specs-codeowners
+        role: member
       - name: rekor-codeowners
         role: maintainer
       - name: rekor-monitor-codeowners
@@ -215,6 +219,8 @@ users:
         role: maintainer
       - name: timestamp-codeowners
         role: member
+      - name: protobuf-specs-codeowners
+        role: member
   - username: hectorj2f
     role: member
     teams:
@@ -267,6 +273,11 @@ users:
       - name: triage
         role: member
       - name: scaffolding-codeowners
+        role: member
+  - username: kommendorkapten
+    role: member
+    teams:
+      - name: protobuf-specs-codeowners
         role: member
   - username: lkatalin
     role: member
@@ -482,4 +493,6 @@ users:
       - name: architecture-doc-team
         role: member
       - name: cosign-codeowners
+        role: member
+      - name: protobuf-specs-codeowners
         role: member

--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -276,7 +276,7 @@ users:
         role: member
   - username: kommendorkapten
     role: member
-    teams: []
+    teams:
       - name: protobuf-specs-codeowners
         role: member
   - username: lkatalin

--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -39,8 +39,8 @@ users:
         role: maintainer
       - name: timestamp-codeowners
         role: member
-      - name: protobuf-specs-codeowners
-        role: member
+      # - name: protobuf-specs-codeowners
+      #   role: member
   - username: bdehamer
     role: member
     teams:
@@ -69,8 +69,8 @@ users:
         role: maintainer
       - name: policy-controller-codeowners
         role: maintainer
-      - name: protobuf-specs-codeowners
-        role: member
+      # - name: protobuf-specs-codeowners
+      #   role: member
       - name: rekor-codeowners
         role: maintainer
       - name: rekor-monitor-codeowners
@@ -219,8 +219,8 @@ users:
         role: maintainer
       - name: timestamp-codeowners
         role: member
-      - name: protobuf-specs-codeowners
-        role: member
+      # - name: protobuf-specs-codeowners
+      #   role: member
   - username: hectorj2f
     role: member
     teams:
@@ -276,9 +276,9 @@ users:
         role: member
   - username: kommendorkapten
     role: member
-    teams:
-      - name: protobuf-specs-codeowners
-        role: member
+    teams: []
+      # - name: protobuf-specs-codeowners
+      #   role: member
   - username: lkatalin
     role: member
     teams:
@@ -494,5 +494,5 @@ users:
         role: member
       - name: cosign-codeowners
         role: member
-      - name: protobuf-specs-codeowners
-        role: member
+      # - name: protobuf-specs-codeowners
+      #   role: member


### PR DESCRIPTION
Signed-off-by: Fredrik Skogman <kommendorkapten@github.com>


#### Summary
Adding a new repository `sigstore/protobuf-specs`. 
Closes https://github.com/sigstore/TSC/issues/38

#### Release Note
N/A

#### Documentation
N/A