### PR TITLE
update scaffolding tests to not require 1.22

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -942,7 +942,7 @@ repositories:
       - username: var-sdk
         permission: maintain
       - username: hectorj2f
-        permission: maintain       
+        permission: maintain
     teams:
       - name: public-good-instance-team
         id: 5623385
@@ -1223,21 +1223,16 @@ repositories:
           - DCO
           - Shellcheck
           - license boilerplate check
-          - e2e tests (v1.22.x, fulcio rekor ctlog e2e, true, 1.19)
-          - e2e tests (v1.22.x, fulcio rekor ctlog e2e, false, 1.19)
           - e2e tests (v1.23.x, fulcio rekor ctlog e2e, false, 1.19)
           - e2e tests (v1.23.x, fulcio rekor ctlog e2e, true, 1.19)
           - e2e tests (v1.24.x, fulcio rekor ctlog e2e, true, 1.19)
           - e2e tests (v1.24.x, fulcio rekor ctlog e2e, false, 1.19)
           - e2e tests (v1.25.x, fulcio rekor ctlog e2e, true, 1.19)
           - e2e tests (v1.25.x, fulcio rekor ctlog e2e, false, 1.19)
-          - e2e tests using release (v1.22.x, fulcio rekor ctlog e2e, 1.19)
           - e2e tests using release (v1.23.x, fulcio rekor ctlog e2e, 1.19)
           - e2e tests using release (v1.24.x, fulcio rekor ctlog e2e, 1.19)
-          - Test github action with TUF (v1.22.x, latest-release, 1.19, test github action with TUF)
           - Test github action with TUF (v1.23.x, latest-release, 1.19, test github action with TUF)
           - Test github action with TUF (v1.24.x, latest-release, 1.19, test github action with TUF)
-          - Test github action with TUF (v1.22.x, v0.4.6, 1.19, test github action with TUF)
           - Test github action with TUF (v1.23.x, v0.4.6, 1.19, test github action with TUF)
           - Test github action with TUF (v1.24.x, v0.4.6, 1.19, test github action with TUF)
         pushRestrictions:


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
With k8s 1.22 getting EOL, drop testing with it, but we need to update the testing requirements to reflect that.

Here you can see the tests that are no longer running block a submission.
https://github.com/sigstore/scaffolding/pull/435


<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->