### PR TITLE
Update required tests due to removals / additions.

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -1242,16 +1242,15 @@ repositories:
           - DCO
           - Shellcheck
           - license boilerplate check
-          - e2e tests (v1.23.x, fulcio rekor ctlog e2e, false, 1.19)
-          - e2e tests (v1.23.x, fulcio rekor ctlog e2e, true, 1.19)
-          - e2e tests (v1.24.x, fulcio rekor ctlog e2e, true, 1.19)
-          - e2e tests (v1.24.x, fulcio rekor ctlog e2e, false, 1.19)
-          - e2e tests (v1.25.x, fulcio rekor ctlog e2e, true, 1.19)
-          - e2e tests (v1.25.x, fulcio rekor ctlog e2e, false, 1.19)
+          - e2e tests (v1.23.x, fulcio rekor ctlog e2e, 1.19)
+          - e2e tests (v1.24.x, fulcio rekor ctlog e2e, 1.19)
+          - e2e tests (v1.25.x, fulcio rekor ctlog e2e, 1.19)
           - e2e tests using release (v1.23.x, fulcio rekor ctlog e2e, 1.19)
           - e2e tests using release (v1.24.x, fulcio rekor ctlog e2e, 1.19)
+          - e2e tests using release (v1.25.x, fulcio rekor ctlog e2e, 1.19)
           - Test github action with TUF (v1.23.x, latest-release, 1.19, test github action with TUF)
           - Test github action with TUF (v1.24.x, latest-release, 1.19, test github action with TUF)
+          - Test github action with TUF (v1.25.x, latest-release, 1.19, test github action with TUF)
         pushRestrictions:
           - scaffolding-codeowners
           - sigstore-oncall


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
These are necessary due to changes to the required tests here:
https://github.com/sigstore/scaffolding/pull/468

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->