### PR TITLE
add sigstore-bot to root-signing repo to be able to merge prs

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -1164,6 +1164,8 @@ repositories:
         permission: maintain
       - username: kommendorkapten
         permission: maintain
+      - username: sigstore-bot
+        permission: push
     teams:
       - name: sigstore-keyholders
         id: 4899309


### PR DESCRIPTION
#### Summary
- add sigstore-bot to root-signing repo to be able to merge prs