### PR TITLE
Standardize enforce admin, disallow force push/deletions across repos

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -23,6 +23,9 @@ repositories:
         permission: admin
     branchesProtection:
       - pattern: main
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
   - name: TSC
@@ -51,7 +54,9 @@ repositories:
         permission: maintain
     branchesProtection:
       - pattern: main
-        allowsDeletions: true
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -89,8 +94,9 @@ repositories:
         permission: admin
     branchesProtection:
       - pattern: main
-        allowsDeletions: true
-        allowsForcePushes: true
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -139,6 +145,8 @@ repositories:
     branchesProtection:
       - pattern: main
         enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -166,6 +174,8 @@ repositories:
           - cosign-codeowners
       - pattern: release-1.13
         enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -262,7 +272,9 @@ repositories:
         permission: maintain
     branchesProtection:
       - pattern: main
-        allowsDeletions: true
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -330,7 +342,9 @@ repositories:
     teams: []
     branchesProtection:
       - pattern: main
-        allowsDeletions: true
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -425,7 +439,8 @@ repositories:
     branchesProtection:
       - pattern: main
         enforceAdmins: true
-        allowsDeletions: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -441,7 +456,8 @@ repositories:
           - fulcio-codeowners
       - pattern: release-1.0
         enforceAdmins: true
-        allowsDeletions: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -485,6 +501,8 @@ repositories:
     branchesProtection:
       - pattern: main
         enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -533,6 +551,8 @@ repositories:
     branchesProtection:
       - pattern: main
         enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -573,6 +593,9 @@ repositories:
     teams: []
     branchesProtection:
       - pattern: main
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
         statusChecks:
@@ -632,6 +655,9 @@ repositories:
         permission: push
     branchesProtection:
       - pattern: main
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
         statusChecks:
@@ -667,6 +693,9 @@ repositories:
         permission: maintain
     branchesProtection:
       - pattern: main
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -741,7 +770,9 @@ repositories:
         permission: admin
     branchesProtection:
       - pattern: main
-        allowsDeletions: true
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -808,6 +839,9 @@ repositories:
         permission: maintain
     branchesProtection:
       - pattern: main
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
         statusChecks:
@@ -963,6 +997,9 @@ repositories:
         permission: push
     branchesProtection:
       - pattern: main
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
         statusChecks:
@@ -1005,8 +1042,8 @@ repositories:
         permission: triage
     branchesProtection:
       - pattern: main
-        enforceAdmins: false
-        allowsDeletions: true
+        enforceAdmins: true
+        allowsDeletions: false
         allowsForcePushes: false
         requiredLinearHistory: true
         requireConversationResolution: false
@@ -1042,7 +1079,7 @@ repositories:
     owner: sigstore
     description: Log monitor for Rekor to verify immutability and monitor entries
     homepageUrl: ""
-    allowAutoMerge: false
+    allowAutoMerge: true
     allowMergeCommit: false
     allowRebaseMerge: true
     allowSquashMerge: true
@@ -1160,6 +1197,9 @@ repositories:
         permission: triage
     branchesProtection:
       - pattern: main
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -1196,8 +1236,9 @@ repositories:
         permission: maintain
     branchesProtection:
       - pattern: main
-        allowsDeletions: true
-        allowsForcePushes: true
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         requiredApprovingReviewCount: 1
         requireCodeOwnerReviews: true
@@ -1245,6 +1286,8 @@ repositories:
     branchesProtection:
       - pattern: main
         enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -1347,7 +1390,9 @@ repositories:
         permission: triage
     branchesProtection:
       - pattern: main
-        allowsDeletions: true
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -1557,6 +1602,8 @@ repositories:
     branchesProtection:
       - pattern: main
         enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
         statusChecks:
@@ -1602,6 +1649,9 @@ repositories:
         permission: maintain
     branchesProtection:
       - pattern: main
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -1674,7 +1724,9 @@ repositories:
         permission: push
     branchesProtection:
       - pattern: main
-        allowsDeletions: true
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         requireConversationResolution: true
         dismissStaleReviews: true
@@ -1706,7 +1758,9 @@ repositories:
     collaborators: []
     branchesProtection:
       - pattern: main
-        allowsDeletions: true
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         requireConversationResolution: true
         dismissStaleReviews: true
@@ -1752,7 +1806,9 @@ repositories:
         permission: pull
     branchesProtection:
       - pattern: main
-        allowsDeletions: true
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -1804,7 +1860,9 @@ repositories:
         permission: maintain
     branchesProtection:
       - pattern: main
-        allowsDeletions: true
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requireSignedCommits: false
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -1849,7 +1907,9 @@ repositories:
         permission: triage
     branchesProtection:
       - pattern: main
-        allowsDeletions: true
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
@@ -1889,7 +1949,7 @@ repositories:
         permission: triage
     branchesProtection:
       - pattern: main
-        enforceAdmins: false
+        enforceAdmins: true
         allowsDeletions: false
         allowsForcePushes: false
         requiredLinearHistory: true


### PR DESCRIPTION
For almost all repos (skipped a few inactive or small ones), I've set: enforceAdmins: true
allowsDeletions: false
allowsForcePushes: false
This enforces that admins can't bypass the rules, and disallows force pushes and branch deletions (bypassing protections). This should have no noticeable effect.

Also enabled auto merge for rekor-monitor

Signed-off-by: Hayden B <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->