### PR TITLE
add sigstore-conformance-codeowners team

### DIFF
--- a/github-sync/github-data/teams.yaml
+++ b/github-sync/github-data/teams.yaml
@@ -110,3 +110,6 @@ teams:
   - name: tuf-root-signing-codeowners
     privacy: closed
     description: ""
+  - name: sigstore-conformance-codeowners
+    privacy: closed
+    description: "Codeowners for sigstore/sigstore-conformance"


### PR DESCRIPTION
per https://github.com/sigstore/TSC/issues/42

will add repo config once team exists

Signed-off-by: Bob Callaway <bcallaway@google.com>