### PR TITLE
sort alphabetical and add tetsuo-cpp, woodruffw, jleightcap and apstickler to the org for sigstore-conformance repo

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -1480,7 +1480,10 @@ repositories:
         permission: push
       - username: tetsuo-cpp
         permission: admin
-    teams: []
+    teams:
+      - name: sigstore-conformance-codeowners
+        id: 7295162
+        permission: mantain
     branchesProtection:
       - pattern: main
         dismissStaleReviews: true

--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -13,6 +13,16 @@ users:
         role: member
       - name: Core Team
         role: maintainer
+  - username: Xynnn007
+    role: member
+    teams:
+      - name: sigstore-rs-codeowners
+        role: member
+  - username: apstickler
+    role: member
+    teams:
+      - name: sigstore-conformance-codeowners
+        role: member
   - username: asraa
     role: member
     teams:
@@ -128,7 +138,9 @@ users:
         role: member
   - username: di
     role: member
-    teams: []
+    teams:
+      - name: sigstore-conformance-codeowners
+        role: member
   - username: dlorenc
     role: member
     teams:
@@ -226,7 +238,7 @@ users:
       - name: helm
         role: member
       - name: policy-controller-codeowners
-        role: member    
+        role: member
   - username: hepwori
     role: member
     teams:
@@ -249,6 +261,11 @@ users:
   - username: inferno-chromium
     role: member
     teams: []
+  - username: jleightcap
+    role: member
+    teams:
+      - name: sigstore-conformance-codeowners
+        role: member
   - username: joshuagl
     role: member
     teams:
@@ -442,6 +459,11 @@ users:
         role: maintainer
       - name: helm-sigstore-codeowners
         role: member
+  - username: tetsuo-cpp
+    role: member
+    teams:
+      - name: sigstore-conformance-codeowners
+        role: member
   - username: thelinuxfoundation
     role: admin
     teams: []
@@ -466,20 +488,20 @@ users:
     teams:
       - name: triage
         role: member
-  - username: yuji-watanabe-jp
-    role: member
-    teams:
-      - name: codeowners-k8s-manifest-sigstore
-        role: member
   - username: wlynch
     role: member
     teams:
       - name: gitsign-codeowners
         role: maintainer
-  - username: Xynnn007
+  - username: woodruffw
     role: member
     teams:
-      - name: sigstore-rs-codeowners
+      - name: sigstore-conformance-codeowners
+        role: member
+  - username: yuji-watanabe-jp
+    role: member
+    teams:
+      - name: codeowners-k8s-manifest-sigstore
         role: member
   - username: znewman01
     role: member


### PR DESCRIPTION
#### Summary
- sort alphabetical and add @tetsuo-cpp, @woodruffw, @jleightcap and @apstickler to the org for `sigstore-conformance` repo
- add sigstore-conformance-codeowners to the sigstore-conformance repo


those users are the maintainers of the repository `sigstore-conformance` and need to be added to the org

Reference: https://github.com/sigstore/TSC/issues/42


after we merge this will perform the users cleanup in the `sigstore-conformance` repo in favor of the new team