### PR TITLE
Add self to sigstore-oncall Github group

### DIFF
--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -305,6 +305,8 @@ users:
         role: member
       - name: sigstore-rs-codeowners
         role: member
+      - name: sigstore-oncall
+        role: member
   - username: loosebazooka
     role: member
     teams:


### PR DESCRIPTION
Signed-off-by: Lily Sturmann <lsturman@redhat.com>

#### Summary
Adding myself to the sigstore oncall group as requested by the docs.

#### Release Note
None

#### Documentation
None