### PR TITLE
Add new team and maintainers for rekor-search-ui

### DIFF
--- a/github-sync/github-data/teams.yaml
+++ b/github-sync/github-data/teams.yaml
@@ -20,6 +20,9 @@ teams:
   - name: codeowners-sigstore-js
     privacy: closed
     description: sigstore-js maintainers
+  - name: codeowners-rekor-search-ui
+    privacy: closed
+    description: rekor-search-ui maintainers
   - name: codeowners-sigstore-python
     privacy: closed
     description: sigstore-python maintainers

--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -47,6 +47,8 @@ users:
   - username: bdehamer
     role: member
     teams:
+      - name: codeowners-rekor-search-ui
+        role: maintainer
       - name: codeowners-sigstore-js
         role: maintainer
   - username: bobcallaway
@@ -191,6 +193,8 @@ users:
   - username: feelepxyz
     role: member
     teams:
+      - name: codeowners-rekor-search-ui
+        role: maintainer
       - name: codeowners-sigstore-js
         role: maintainer
   - username: flavio


### PR DESCRIPTION
## What?
A new team for [rekor-search-ui](https://github.com/sigstore/rekor-search-ui)

## Why these maintainers?
@bdehamer and @feelepxyz have done all of the work on [rekor-search-ui](https://github.com/sigstore/rekor-search-ui) since it was donated, including significant UI changes and support for contemporary InToto schemas. They also maintain [sigstore-js](https://github.com/sigstore/sigstore-js).