### PR TITLE
Add SIG teams and maintainers

### DIFF
--- a/github-sync/github-data/teams.yaml
+++ b/github-sync/github-data/teams.yaml
@@ -74,6 +74,12 @@ teams:
   - name: security-response-team
     privacy: closed
     description: ""
+  - name: sigstore-sig-clients
+    privacy: closed
+    description: "Home of the SIG for client libraries and CLIs"
+  - name: sigstore-sig-public-good-operations
+    privacy: closed
+    description: "Home of the SIG for public good operations"
   - name: sigstore-codeowners
     privacy: closed
     description: 'Note: this is for the sigstore repo, not for the entire organization'

--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -437,6 +437,8 @@ users:
   - username: pwelch
     role: member
     teams:
+      - name: sigstore-sig-public-good-operations
+        role: maintainer
       - name: sigstore-oncall
         role: member
   - username: rawlingsj
@@ -506,6 +508,8 @@ users:
   - username: znewman01
     role: member
     teams:
+      - name: sigstore-sig-clients
+        role: maintainer
       - name: triage
         role: member
       - name: architecture-doc-team


### PR DESCRIPTION
## What
Teams/membership for two new SIGs approved by TSC:

* Public good operations
* Clients

## Why
Helps us formalize existing ad hoc leadership into groups for accountability, stability, etc.

Signed-off-by: Trevor Rosen <trevrosen@github.com>