### PR TITLE
enable dismissStaleReviews for sig-clients and sig-public-good-operations repos

### DIFF
--- a/github-sync/github-data/repositories.yaml
+++ b/github-sync/github-data/repositories.yaml
@@ -2034,6 +2034,7 @@ repositories:
         requireCodeOwnerReviews: false
         restrictDismissals: true
         requireBranchesUpToDate: false
+        dismissStaleReviews: true
         statusChecks:
           - DCO
   - name: sig-public-good-operations
@@ -2074,6 +2075,7 @@ repositories:
         requireCodeOwnerReviews: false
         restrictDismissals: true
         requireBranchesUpToDate: false
+        dismissStaleReviews: true
         statusChecks:
           - DCO
   - name: sigstore-website


### PR DESCRIPTION


#### Summary
- enable dismissStaleReviews for sig-clients and sig-public-good-operations repos

Fixes: https://github.com/sigstore/sig-clients/issues/2
Fixes: https://github.com/sigstore/sig-public-good-operations/issues/2