### PR TITLE
Add Sally to sigstore-oncall

### DIFF
--- a/github-sync/github-data/users.yaml
+++ b/github-sync/github-data/users.yaml
@@ -522,3 +522,8 @@ users:
         role: member
       - name: sigstore-go-codeowners
         role: member
+  - username: sallyom
+    role: member
+    teams:
+      - name: sigstore-oncall
+        role: member


### PR DESCRIPTION
#### Summary
Add Sally to sigstore-oncall as discussed on Slack. IIUC, this PR is the appropriate way to add her to the repos where she can being to read about how to start the onboarding process.

#### Release Note
n/a

#### Documentation
n/a
