### PR TITLE
remove tests from required status checks for scaffolding

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1495,15 +1495,6 @@ repositories:
           - DCO
           - Shellcheck
           - license boilerplate check
-          - e2e tests (v1.23.x, fulcio rekor ctlog e2e, 1.20.x)
-          - e2e tests (v1.24.x, fulcio rekor ctlog e2e, 1.20.x)
-          - e2e tests (v1.25.x, fulcio rekor ctlog e2e, 1.20.x)
-          - e2e tests using release (v1.23.x, fulcio rekor ctlog e2e, 1.20.x)
-          - e2e tests using release (v1.24.x, fulcio rekor ctlog e2e, 1.20.x)
-          - e2e tests using release (v1.25.x, fulcio rekor ctlog e2e, 1.20.x)
-          - Test github action with TUF (v1.23.x, latest-release, 1.20.x, test github action with TUF)
-          - Test github action with TUF (v1.24.x, latest-release, 1.20.x, test github action with TUF)
-          - Test github action with TUF (v1.25.x, latest-release, 1.20.x, test github action with TUF)
         pushRestrictions:
           - scaffolding-codeowners
           - sigstore-oncall


### PR DESCRIPTION
https://github.com/sigstore/scaffolding/pull/715 changed the test behavior of `scaffolding` to optionally only run certain tests on terraform vs non-terraform PRs