### PR TITLE
update/sync sigstore-maven-plugin

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1895,7 +1895,7 @@ repositories:
   - name: sigstore-maven-plugin
     owner: sigstore
     description: sigstore maven plugin
-    homepageUrl: ""
+    homepageUrl: "https://sigstore.github.io/sigstore-maven-plugin/"
     defaultBranch: main
     allowAutoMerge: false
     allowMergeCommit: true
@@ -1912,6 +1912,9 @@ repositories:
     visibility: public
     licenseTemplate: ""
     topics: []
+    pages:
+      branch: gh-pages
+      path: /
     collaborators:
       - username: hboutemy
         permission: maintain


### PR DESCRIPTION
#### Summary

- update/sync sigstore-maven-plugin
follow up of #314 #317 
the repo was an existing one and then we need to import that manually to the automation works, this is already imported and now jus to sync the missing data
