### PR TITLE
drop codeql status check as required, already have analyze (go)

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1463,7 +1463,6 @@ repositories:
         requireLastPushApproval: true
         statusChecks:
           - Analyze (go)
-          - CodeQL
           - DCO
           - Shellcheck
           - license boilerplate check


### PR DESCRIPTION
#### Summary

- drop codeql status check as required, already have analyze (go)

need for https://github.com/sigstore/scaffolding/pull/758