### PR TITLE
Cleanup members without teams, add rekor-monitor maintainer

### DIFF
--- a/github-sync/github-data/sigstore/users.yaml
+++ b/github-sync/github-data/sigstore/users.yaml
@@ -36,8 +36,6 @@ users:
         role: member
       - name: tuf-root-signing-codeowners
         role: member
-      - name: security-response-team
-        role: maintainer
       - name: sigstore-go-codeowners
         role: member
       - name: timestamp-codeowners
@@ -98,11 +96,10 @@ users:
   - username: codysoyland
     role: member
     teams:
+      - name: security-response-team
+        role: member
       - name: sigstore-oncall
         role: member
-  - username: coyote240
-    role: member
-    teams: []
   - username: cpanato
     role: admin
     teams:
@@ -148,8 +145,6 @@ users:
       - name: policy-controller-codeowners
         role: maintainer
       - name: rekor-codeowners
-        role: maintainer
-      - name: security-response-team
         role: maintainer
       - name: sigstore-codeowners
         role: maintainer
@@ -236,7 +231,7 @@ users:
       - name: sigstore-oncall
         role: member
       - name: security-response-team
-        role: maintainer
+        role: member
       - name: timestamp-codeowners
         role: member
       - name: protobuf-specs-codeowners
@@ -316,9 +311,6 @@ users:
         role: member
       - name: tuf-root-signing-codeowners
         role: member
-  - username: kpk47
-    role: member
-    teams: []
   - username: lkatalin
     role: member
     teams:
@@ -330,6 +322,8 @@ users:
     role: member
     teams:
       - name: codeowners-maven-sigstore
+        role: member
+      - name: rekor-monitor-codeowners
         role: member
       - name: sigstore-java-codeowners
         role: maintainer
@@ -418,9 +412,6 @@ users:
     teams:
       - name: sigstore-keyholders
         role: member
-  - username: n3wscott
-    role: member
-    teams:
   - username: naveensrinivasan
     role: member
     teams:


### PR DESCRIPTION
Adds a maintainer for rekor-monitor, removes members without teams. Also sync who is in the security response team.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
