### PR TITLE
sigstore/repositories: fix status checks on gh-action-sigstore-python

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -654,13 +654,8 @@ repositories:
         requireLastPushApproval: true
         statusChecks:
           - DCO
-          - selftest-glob
-          - selftest
-          - selftest-custom-paths
-          - selftest-staging
-          - selftest-verify-issuer
-          - selftest-identity-token
-          - selftest-upload-artifacts
+          - lint
+          - all-selftests-pass
   - name: helm-charts
     owner: sigstore
     description: Helm charts for sigstore project


### PR DESCRIPTION
I noticed that these were out-of-sync with our actual required status checks, causing our checks to get wiped whenever this config is deployed. I've updated them here.