### PR TITLE
sigstore-conformance: add jku as maintainer

### DIFF
--- a/github-sync/github-data/sigstore-conformance/repositories.yaml
+++ b/github-sync/github-data/sigstore-conformance/repositories.yaml
@@ -55,6 +55,8 @@ repositories:
         permission: maintain
       - username: woodruffw
         permission: maintain
+      - username: jku
+        permission: maintain
     teams: []
     branchesProtection:
       - pattern: main


### PR DESCRIPTION
Per Slack discussion: this adds another maintainer to https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon.

Specifically, it adds @jku (who is already a Sigstore contributor + trusted reviewer).

Shouldn't be merged until @jku actually agrees to accept the maintain bit here -- I don't want to sign him up for things arbitrarily. This is mostly to make sure that PRs to this repo have a slightly larger reviewer timezone window (since I'm US EST and @tetsuo-cpp is Australia EST).