### PR TITLE
Add user jku and team tuf-root-signing-staging-codeowners

### DIFF
--- a/github-sync/github-data/sigstore/teams.yaml
+++ b/github-sync/github-data/sigstore/teams.yaml
@@ -107,6 +107,9 @@ teams:
   - name: tuf-root-signing-codeowners
     privacy: closed
     description: ""
+  - name: tuf-root-signing-staging-codeowners
+    privacy: closed
+    description: ""
   - name: sigstore-conformance-codeowners
     privacy: closed
     description: "Codeowners for sigstore/sigstore-conformance"

--- a/github-sync/github-data/sigstore/users.yaml
+++ b/github-sync/github-data/sigstore/users.yaml
@@ -226,6 +226,8 @@ users:
         role: member
       - name: tuf-root-signing-codeowners
         role: member
+      - name: tuf-root-signing-staging-codeowners
+        role: member
       - name: sigstore-oncall
         role: member
       - name: security-response-team
@@ -273,6 +275,11 @@ users:
     teams:
       - name: public-good-instance-team
         role: member
+  - username: jku
+    role: member
+    teams:
+      - name: tuf-root-signing-staging-codeowners
+        role: member
   - username: jleightcap
     role: member
     teams:
@@ -308,6 +315,8 @@ users:
       - name: sigstore-go-codeowners
         role: member
       - name: tuf-root-signing-codeowners
+        role: member
+      - name: tuf-root-signing-staging-codeowners
         role: member
   - username: lkatalin
     role: member


### PR DESCRIPTION
* tuf-root-signing-staging-codeowners is for maintainers of planned root-signing-staging repository (see #345)
* New user jku as well as kommendorkapten & haydentherapper are added to the new team

Fixes #347

---

I don't really know what I'm doing with pulumi so feedback is welcome.