### PR TITLE
Update collaborators for sigstore-conformance

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1632,13 +1632,13 @@ repositories:
       - conformance
       - tests
     collaborators:
-      - username: apstickler
-        permission: admin
       - username: asraa
         permission: push
       - username: bobcallaway
         permission: admin
       - username: haydentherapper
+        permission: push
+      - username: jku
         permission: push
       - username: loosebazooka
         permission: push


### PR DESCRIPTION
Adds @jku, removes @apstickler.

(cc @woodruffw, @haydentherapper)