### PR TITLE
add tuf-root-signing-staging to root-signing repo

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1341,6 +1341,9 @@ repositories:
       - name: tuf-root-signing-codeowners
         id: 6378909
         permission: maintain
+      - name: tuf-root-signing-staging
+        id: 8790813
+        permission: maintain
       - name: triage
         id: 5643322
         permission: triage


### PR DESCRIPTION

#### Summary
- add tuf-root-signing-staging to root-signing repo

follow up of https://github.com/sigstore/community/pull/348

cc @jku