### PR TITLE
fix settings for root-signing-staging

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1421,7 +1421,7 @@ repositories:
     allowSquashMerge: false
     archived: false
     autoInit: false
-    deleteBranchOnMerge: false
+    deleteBranchOnMerge: true
     hasDownloads: false
     hasIssues: true
     hasProjects: false
@@ -1450,7 +1450,7 @@ repositories:
         enforceAdmins: true
         allowsDeletions: false
         allowsForcePushes: false
-        requiredLinearHistory: true
+        requiredLinearHistory: false
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
         requireLastPushApproval: true
@@ -1464,7 +1464,7 @@ repositories:
         enforceAdmins: true
         allowsDeletions: false
         allowsForcePushes: false
-        requiredLinearHistory: true
+        requiredLinearHistory: false
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
         requireLastPushApproval: true


### PR DESCRIPTION
#### Summary
- fix settings for root-signing-staging


for `requiredLinearHistory` we need to set the squash-merge, but this repo uses merge only, for now, we might change that

also enable the delete branches in merge to cleanup

now the pipeline will be green again

Fixes: #354 