### PR TITLE
repositories: add myself as admin to root-signing-staging

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1431,6 +1431,8 @@ repositories:
     licenseTemplate: ""
     topics: []
     collaborators:
+      - username: jku
+        permission: admin
       - username: sigstore-bot
         permission: push
       - username: sigstore-review-bot


### PR DESCRIPTION
We need GitHub Actions Variables in root-signing-staging: Add myself
as admin collaborator to be able to add them.

Fixes #360
