### PR TITLE
sigstore/repositories: add @jku to sigstore-python

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -2155,6 +2155,8 @@ repositories:
         permission: maintain
       - username: woodruffw
         permission: maintain
+      - username: jku
+        permission: maintain
       - username: tnytown
         permission: triage
     teams:


### PR DESCRIPTION
This adds @jku as another maintainer of `sigstore-python`. @jku is already a member of the Sigstore org and maintainer of the conformance suite + an active contributor to `sigstore-python`, so this merely officializes his capacities 🙂 