### PR TITLE
repositories: @jku maintains gh-action-sigstore-python

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -693,6 +693,8 @@ repositories:
         permission: admin
       - username: tnytown
         permission: triage
+      - username: jku
+        permission: maintain
     teams: []
     branchesProtection:
       - pattern: main


### PR DESCRIPTION
Follow-on to #368.

CC @sigstore/core-team 