### PR TITLE
Upgrade bot perm to triage in public-good-instance

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1108,7 +1108,7 @@ repositories:
       - username: TomHennen
         permission: triage
       - username: sigstore-bot
-        permission: pull
+        permission: triage
     teams:
       - name: public-good-instance-team
         id: 5623385


### PR DESCRIPTION
Upgrade sigstore-bot's collaborator permissions on sigstore/public-good-instance from 'pull' to 'triage', which has all the same permissions as 'pull' but will additionally allow the bot to create issues with labels on them[1].

[1] https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role

Relates to https://github.com/sigstore/public-good-instance/issues/486