### PR TITLE
Create new role for sigstore-bot in root-signing-staging

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1467,9 +1467,7 @@ repositories:
       - username: jku
         permission: admin
       - username: sigstore-bot
-        permission: push
-      - username: sigstore-review-bot
-        permission: push
+        permission: push-with-bypass
     teams:
       - name: tuf-root-signing-staging-codeowners
         id: 8790813

--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1467,7 +1467,7 @@ repositories:
       - username: jku
         permission: admin
       - username: sigstore-bot
-        permission: push-with-bypass
+        permission: write-with-bypass
     teams:
       - name: tuf-root-signing-staging-codeowners
         id: 8790813

--- a/github-sync/github-data/sigstore/roles.yaml
+++ b/github-sync/github-data/sigstore/roles.yaml
@@ -1,5 +1,5 @@
 customRoles:
-  - name: push-with-bypass
-    baseRole: push
-    description: Push role with an additional permission to bypass branch protection
+  - name: write-with-bypass
+    baseRole: write
+    description: write role with an additional permission to bypass branch protection
     permissions: [bypass_branch_protection]

--- a/github-sync/github-data/sigstore/roles.yaml
+++ b/github-sync/github-data/sigstore/roles.yaml
@@ -1,4 +1,4 @@
-repositoryRoles:
+customRoles:
   - name: push-with-bypass
     baseRole: push
     description: Push role with an additional permission to bypass branch protection

--- a/github-sync/github-data/sigstore/roles.yaml
+++ b/github-sync/github-data/sigstore/roles.yaml
@@ -1,0 +1,5 @@
+repositoryRoles:
+  - name: push-with-bypass
+    baseRole: push
+    description: Push role with an additional permission to bypass branch protection
+    permissions: [bypass_branch_protection]


### PR DESCRIPTION
* Role allows bypassing branch protections
* This replaces the use of a separate review bot
* Plan is to test this out in root-signing-staging, and later apply same structure to root-signing


See sigstore/github-sync#117 for more context. This is a draft until sigstore/github-sync#118 is merged.
