### PR TITLE
Add Pages publishing to root-signing-staging

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1459,6 +1459,8 @@ repositories:
     hasIssues: true
     hasProjects: false
     hasWiki: false
+    pages:
+      buildType: workflow
     vulnerabilityAlerts: true
     visibility: public
     licenseTemplate: ""


### PR DESCRIPTION
This requires support for "workflow" build type (see https://github.com/sigstore/github-sync/pull/122)