### PR TITLE
root-signing-staging: Do not use the new role yet

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1467,7 +1467,9 @@ repositories:
       - username: jku
         permission: admin
       - username: sigstore-bot
-        permission: write-with-bypass
+        permission: push
+      - username: sigstore-review-bot
+        permission: push
     teams:
       - name: tuf-root-signing-staging-codeowners
         id: 8790813


### PR DESCRIPTION
This is a revert of half of #395.

'pulumi up' fails with this:

    422 Role `write-with-bypass` is not available for the
    sigstore/root-signing-staging repository.

I'm not sure why the custom role is not found. Let's revert this and I will investigate.
