### PR TITLE
Add bot branch protection bypass in root-signing-staging

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1470,8 +1470,6 @@ repositories:
         permission: admin
       - username: sigstore-bot
         permission: push
-      - username: sigstore-review-bot
-        permission: push
     teams:
       - name: tuf-root-signing-staging-codeowners
         id: 8790813
@@ -1497,6 +1495,8 @@ repositories:
           - sigstore-bot
         dismissalRestrictions:
           - tuf-root-signing-staging-codeowners
+        pullRequestBypassers:
+          - sigstore-bot
       - pattern: publish
         enforceAdmins: true
         allowsDeletions: false

--- a/github-sync/github-data/sigstore/roles.yaml
+++ b/github-sync/github-data/sigstore/roles.yaml
@@ -1,5 +1,0 @@
-customRoles:
-  - name: write-with-bypass
-    baseRole: write
-    description: write role with an additional permission to bypass branch protection
-    permissions: [bypass_branch_protection]


### PR DESCRIPTION
This uses sigstore/github-sync#127 (a new field in repository branch protection).

The purpose here is to 
* give sigstore-bot ability to bypass PR requirement for frequent online signing in sigstore/root-signing-staging 
* still require PRs and reviews from developers

I originally attempted to use a custom role for this. That has failed so the first commit removes the role. Closes #401.
 
 
-- 
Something to look for in pulumi preview: when I manually modify the _Allow specified actors to bypass required pull requests_ in GitHub UI for root-signing-staging, `sigstore/sigstore-oncall` is already in the list somehow. Maybe that is some org setting? 