### PR TITLE
Update sigstore-go required checks to include platform matrix build jobs

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1857,7 +1857,9 @@ repositories:
         requireLastPushApproval: true
         statusChecks:
           - DCO
-          - build
+          - build (macos-latest)
+          - build (ubuntu-latest)
+          - build (windows-latest)
           - lint
           - conformance
           - CodeQL


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Related to https://github.com/sigstore/sigstore-go/pull/103, which introduces platform specific matrix jobs for the build workflow. The currently required `build` workflow on that PR is stuck because it is no longer being run as originally required in the required status checks.

Workflow changes in that PR mean that sigstore-go pull requests now run the [build workflow](https://github.com/sigstore/sigstore-go/blob/10717b83fa3412f1a9b613a8a423e79c35367e93/.github/workflows/build.yml) on the `ubuntu-latest`, `macos-latest`, and `windows-latest` platforms, which changes the names of the build status checks that are running.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
