### PR TITLE
Remove policy-controller test against k8s 1.22 as blocking

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -989,7 +989,6 @@ repositories:
           - license boilerplate check
           - lint
           - verify
-          - e2e tests (v1.22.x)
           - e2e tests (v1.23.x)
           - e2e tests (v1.24.x)
           - e2e tests (v1.25.x)


### PR DESCRIPTION
will unblock https://github.com/sigstore/policy-controller/pull/1269, which is fixing currently failing CI in policy-controller