### PR TITLE
remove cosign gh checks due to job removal

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -225,9 +225,6 @@ repositories:
           - Run unit tests (ubuntu-latest)
           - Run unit tests (windows-latest)
           - Verify Docgen
-          - build (macos-latest)
-          - build (ubuntu-latest)
-          - build (windows-latest)
           - License and Vulnerability Scan / Scan dependencies for license compliance and vulnerabilities
           - license boilerplate check
           - lint


### PR DESCRIPTION

#### Summary
- remove cosign gh checks due to job removal

need this to be able to merge: https://github.com/sigstore/cosign/pull/3629