### PR TITLE
start move of reusable-release script out of s/s to community repo

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,0 +1,75 @@
+name: Cut Release
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        required: false
+        type: string
+        description: 'Release tag. Will increment patch version if not specified.'
+        default: ''
+      key_ring:
+        required: false
+        type: string
+        description: 'Key ring for cosign key'
+      key_name:
+        required: false
+        type: string
+        description: 'Key name for cosign key'
+      workload_identity_provider:
+        required: true
+        type: string
+        description: 'Workload idenitty provider to authenticate acceses.'
+      service_account:
+        required: true
+        type: string
+        description: 'Service account to run the release.'
+      repo:
+        required: true
+        type: string
+        description: 'The Sigstore repo to release.'
+
+
+jobs:
+  cut-release:
+    name: Cut release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      PROJECT_ID: 'projectsigstore'
+      RELEASE_TAG: ${{ inputs.release_tag }}
+    steps:
+      - name: Check actor access
+        if: ${{ !contains( fromJson('["bobcallaway","cpanato","lukehinds","priyawadhwa",haydentherapper"]'), github.actor ) }}
+        run: exit 1
+
+      - name: Checkout out repo
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          path: ./src/github.com/sigstore/${{ inputs.repo }}
+
+      - name: Set release tag if not specified
+        if: ${{ inputs.release_tag == '' }}
+        run: |
+          git fetch --all --tags
+          LATEST_DIGEST=`git rev-list --tags --max-count=1`
+          LATEST_TAG=`git describe --tags ${LATEST_DIGEST}`
+          NEW_VERSION=`echo "${TAG}" | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g'`
+          echo "RELEASE_TAG=${NEW_VERSION}" >> $GITHUB_ENV
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
+        with:
+          workload_identity_provider: ${{ inputs.workload_identity_provider }}
+          service_account: ${{ inputs.service_account }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Start cloudbuild job
+        working-directory: ./src/github.com/sigstore/${{ inputs.repo }}
+        run: gcloud builds submit --no-source --async --config release/cloudbuild.yaml --substitutions _GIT_TAG=${{ env.RELEASE_TAG }},_TOOL_ORG=sigstore,_TOOL_REPO=${{ inputs.repo }},_STORAGE_LOCATION=${{ inputs.repo }}-releases,_KEY_RING=release-cosign,_KEY_NAME=cosign,_GITHUB_USER=sigstore-bot --project=${{ env.PROJECT_ID }}


### PR DESCRIPTION
our reusable release script should reside here, not in sigstore/sigstore