### PR TITLE
Update repositories.yaml

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -2007,8 +2007,8 @@ repositories:
         statusChecks:
           - Validation
           - DCO
-          - conformance (17)
-          - conformance (11)
+          - conformance (17, production)
+          - conformance (11, production)
           - build (17)
           - build (11)
     webCommitSignoffRequired: true


### PR DESCRIPTION
sigstore-java added a matrix to conformance tests to separate staging and production.

staging is optional, since it can be flaky when testing out new infrastructure upgrades
