### PR TITLE
root-signing-staging: Update branch protection

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1558,6 +1558,10 @@ repositories:
         restrictDismissals: true
         pushRestrictions:
           - sigstore-bot
+        dismissalRestrictions:
+          - tuf-root-signing-staging-codeowners
+        pullRequestBypassers:
+          - sigstore-bot
     webCommitSignoffRequired: true
   - name: ruby-sigstore
     owner: sigstore


### PR DESCRIPTION
The intention is that both "publish" and "main" branches can be pushed to by sigstore-bot. Currently this is not true for "publish" (although somehow it was until yesterday?)

Copy the settings so "publish" has the same ones as "main".


This fixes #449, should unblock sigstore/root-signing-staging#130.  Note that I'm not sure why the issue appears now but I think it has to do with the pulumi issues we were having...

CC @kommendorkapten @haydentherapper 