### PR TITLE
root-signing: Prepare for tuf-on-ci migration

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1393,13 +1393,13 @@ repositories:
     webCommitSignoffRequired: true
   - name: root-signing
     owner: sigstore
-    description: ""
+    description: "TUF repository for Sigstore trust root"
     homepageUrl: ""
     defaultBranch: main
     allowAutoMerge: true
-    allowMergeCommit: false
-    allowRebaseMerge: true
-    allowSquashMerge: true
+    allowMergeCommit: true
+    allowRebaseMerge: false
+    allowSquashMerge: false
     archived: false
     autoInit: false
     deleteBranchOnMerge: true
@@ -1434,7 +1434,7 @@ repositories:
         enforceAdmins: true
         allowsDeletions: false
         allowsForcePushes: false
-        requiredLinearHistory: true
+        requiredLinearHistory: false
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
         requireLastPushApproval: true
@@ -1444,16 +1444,33 @@ repositories:
           - yamllint
           - test
           - lint
-          - validate
-          - client
         pushRestrictions:
           - tuf-root-signing-codeowners
-          - sigstore-keyholders
           - sigstore-bot
           - sigstore-review-bot
         dismissalRestrictions:
           - tuf-root-signing-codeowners
           - sigstore-keyholders
+        pullRequestBypassers:
+          - sigstore-bot
+      - pattern: publish
+        enforceAdmins: true
+        allowsDeletions: false
+        allowsForcePushes: false
+        requiredLinearHistory: false
+        dismissStaleReviews: true
+        requiredApprovingReviewCount: 1
+        requireLastPushApproval: true
+        restrictDismissals: true
+        pushRestrictions:
+          - tuf-root-signing-codeowners
+          - sigstore-bot
+          - sigstore-review-bot
+        dismissalRestrictions:
+          - tuf-root-signing-codeowners
+          - sigstore-keyholders
+        pullRequestBypassers:
+          - sigstore-bot
       - pattern: test-ceremony/*
         enforceAdmins: true
         allowsDeletions: false

--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1450,7 +1450,6 @@ repositories:
           - sigstore-review-bot
         dismissalRestrictions:
           - tuf-root-signing-codeowners
-          - sigstore-keyholders
         pullRequestBypassers:
           - sigstore-bot
       - pattern: publish
@@ -1468,7 +1467,6 @@ repositories:
           - sigstore-review-bot
         dismissalRestrictions:
           - tuf-root-signing-codeowners
-          - sigstore-keyholders
         pullRequestBypassers:
           - sigstore-bot
       - pattern: test-ceremony/*


### PR DESCRIPTION
As part of https://github.com/sigstore/root-signing/issues/1247 root-signing requires some project setting changes:
* Allow and encourage merge commits: signing event branches are collaboration branches where individual commits have different authors and actual meaning.
* Do not require linear history: signing events make sense as slightly longer lived branches: preserving this history makes sense
* Remove two required checks that are replaced by tuf-on-ci checks (which can be made required in a later commit)
* Add branch protection for "publish"
* Modify branch protection for "main":
  * Remove sigstore-keyholders from pushRestrictions list: this looks like a mistake, keyholders should not have permissions for main
  * Add sigstore-bot as a PR bypasser (this is how online signing happens)

CC @kommendorkapten @haydentherapper 