### PR TITLE
Add new team for push access to model transparency.

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -961,6 +961,9 @@ repositories:
       - name: model-transparency-codeowners
         id: 9730895
         permission: admin
+      - name: model-transparency
+        id: 9730895  # TODO: update with the new team ID once team is created
+        permission: push
     branchesProtection:
       - pattern: main
         enforceAdmins: true

--- a/github-sync/github-data/sigstore/teams.yaml
+++ b/github-sync/github-data/sigstore/teams.yaml
@@ -53,6 +53,9 @@ teams:
   - name: model-transparency-codeowners
     privacy: closed
     description: "Code owners for ML model transparency"
+  - name: model-transparency
+    privacy: closed
+    description: "Write access for ML model transparency"
   - name: policy-controller-codeowners
     privacy: closed
     description: Codeowners for sigstore/policy-controller

--- a/github-sync/github-data/sigstore/users.yaml
+++ b/github-sync/github-data/sigstore/users.yaml
@@ -475,6 +475,11 @@ users:
     teams:
       - name: model-transparency-codeowners
         role: member
+  - username: spencerschrock
+    role: member
+    teams:
+      - name: model-transparency
+        role: member
   - username: steiza
     role: member
     teams:


### PR DESCRIPTION
#### Summary
Spencer is joining the ML model transparency effort, so we're creating a new team and adding him to the team.

There is one TODO to replace the team ID. That one I don't get until after this lands and GitHub creates the team. At that time, I'll open a new PR

#### Release Note
NONE

#### Documentation
NONE