### PR TITLE
Fix team ID for `model-transparency` team

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -962,7 +962,7 @@ repositories:
         id: 9730895
         permission: admin
       - name: model-transparency
-        id: 9730895  # TODO: update with the new team ID once team is created
+        id: 10329477
         permission: push
     branchesProtection:
       - pattern: main


### PR DESCRIPTION
#### Summary
In #454 we added a new team but we could not see the team ID until after the Pulumi sync. Similar to #421, we got it from inspecting the avatar of the team at https://github.com/orgs/sigstore/teams/model-transparency.

#### Release Note
NONE

#### Documentation
NONE