### PR TITLE
Add myself to `model-transparency` team to debug

### DIFF
--- a/github-sync/github-data/sigstore/users.yaml
+++ b/github-sync/github-data/sigstore/users.yaml
@@ -418,6 +418,8 @@ users:
     teams:
       - name: model-transparency-codeowners
         role: member
+      - name: model-transparency
+        role: member
   - username: mnm678
     role: member
     teams:


### PR DESCRIPTION
#### Summary
It seems `model-transparency-codeowners` lost access to `model-transparency` repo, so I'm adding myself to the other team to see what permissions are granted there, while debugging.

Looking at the `repositories.yaml` file, there are other repos with multiple teams, so I'm not sure yet what is missing.

#### Release Note
NONE

#### Documentation
NONE