### PR TITLE
Change `model-transparency` access to `maintain`.

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -963,7 +963,7 @@ repositories:
         permission: admin
       - name: model-transparency
         id: 10329477
-        permission: push
+        permission: maintain
     branchesProtection:
       - pattern: main
         enforceAdmins: true


### PR DESCRIPTION
#### Summary

Still debugging why we cannot have 2 teams in the repo, but also trying to fix permissions for the new team. At least this would guarantee that the new team has the right permissions (I think).

#### Release Note
NONE

#### Documentation
NONE