### PR TITLE
Add tips regarding teams to prevent last confusion

### DIFF
--- a/github-sync/README.md
+++ b/github-sync/README.md
@@ -81,6 +81,19 @@ example:
       permission: push # Must be one of `pull`, `triage`, `push`, `maintain`, or `admin`. Defaults to `pull`.
 ```
 
+> [!WARNING]
+> When adding multiple teams to the same repository, don't duplicate the team
+> ID! Doing so might result in loss of permissions to the team with the
+> duplicated ID. Instead, skip the ID to the new team if not already known
+> (prefer creating a team in one PR and adding it to the repo in a subsequent
+> PR).
+
+> [!TIP]
+> To get the team ID, inspect the URL of the avatar on the team page (e.g., for
+> `https://github.com/orgs/sigstore/teams/model-transparency`, the ID is
+> 10329477 as the avatar URL is
+> https://avatars.githubusercontent.com/t/10329477).
+
 If you need to configure the GitHub Pages you can add the following definition
 
 ```yaml


### PR DESCRIPTION
#### Summary
Last time, when I tried to update the `model_transparency` repo, I added a `model_transparency` team and added it to the repo in the same PR (#454), with a plan to fix team ID in the next one (#456). This actually caused a problem: the `model_transparency_codeowners` team lost access to the repository.

This was because the team ID was reused, so Pulumi removed permissions when creating the new team.

#### Release Note
NONE

#### Documentation
NONE