### PR TITLE
Archive old sigstore-maven plugin repositories

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -2097,7 +2097,7 @@ repositories:
     allowMergeCommit: true
     allowRebaseMerge: true
     allowSquashMerge: true
-    archived: false
+    archived: true
     autoInit: false
     deleteBranchOnMerge: false
     hasDownloads: true
@@ -2131,7 +2131,7 @@ repositories:
     allowMergeCommit: true
     allowRebaseMerge: true
     allowSquashMerge: true
-    archived: false
+    archived: true
     autoInit: false
     deleteBranchOnMerge: false
     hasDownloads: true


### PR DESCRIPTION
Archive older maven plugin repositroies

Needs: https://github.com/sigstore/sigstore-maven/pull/13 and https://github.com/sigstore/sigstore-maven-plugin/pull/174