### PR TITLE
Remove some required checks from root-signing for migration

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1429,8 +1429,6 @@ repositories:
         statusChecks:
           - DCO
           - yamllint
-          - test
-          - lint
         pushRestrictions:
           - tuf-root-signing-codeowners
           - sigstore-bot


### PR DESCRIPTION
"test" and "lint" do not exist anymore in future root-signing : remove them from required list

There are a few new checks we should make required but that only makes sense after the workflows are running.

This fixes https://github.com/sigstore/root-signing/issues/1314 and is part of https://github.com/sigstore/root-signing/issues/1247

CC @haydentherapper 