### PR TITLE
Add more required CI to model_transparency.

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -974,7 +974,12 @@ repositories:
         restrictDismissals: true
         requireLastPushApproval: true
         statusChecks:
-          - DCO # TODO: probably need to add more to match with all the other checks we enforce
+          - DCO
+          - Lint / Lint whitespace (pull_request)
+          - Lint / Python lint (pull_request)
+          - Lint / Type Check (pull_request)
+          - Run unit tests / Signing with Python 3.11 on Linux (pull_request)
+          - Run unit tests / Signing with Python 3.12 on Linux (pull_request)
         pushRestrictions:
           - model-transparency-codeowners
         dismissalRestrictions:


### PR DESCRIPTION
#### Summary
Add a few more required CI checks for model-transparency repository to make sure we don't accidentaly merge PRs before these get a chance to run (due to slow down in provisioning or due to misconfiguration). We're adding several lint jobs and jobs to test the model signing library on Linux only. The repository has several other CI jobs, but those will not be marked as required.

These are added and tested in
https://github.com/sigstore/model-transparency/pull/283.

#### Release Note
NONE

#### Documentation
NONE