### PR TITLE
Properly configure the required checks for model-transparency

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -975,11 +975,11 @@ repositories:
         requireLastPushApproval: true
         statusChecks:
           - DCO
-          - Lint / Lint whitespace (pull_request)
-          - Lint / Python lint (pull_request)
-          - Lint / Type Check (pull_request)
-          - Run unit tests / Signing with Python 3.11 on Linux (pull_request)
-          - Run unit tests / Signing with Python 3.12 on Linux (pull_request)
+          - Lint whitespace
+          - Python lint
+          - Type Check
+          - Signing with Python 3.11 on Linux
+          - Signing with Python 3.12 on Linux
         pushRestrictions:
           - model-transparency-codeowners
         dismissalRestrictions:


### PR DESCRIPTION
#### Summary
I was wrong in #478: the checks need to be as they show up in the job name, not how they show up in the GHA summary at the bottom of the PR.

Since I used the wrong ones, https://github.com/sigstore/model-transparency/pull/284 is now waiting on checks that cannot run. But I can fix that by closing and reopening once the required checks are in the correct format.

Sorry for double work in reviewing!

#### Release Note
NONE
#### Documentation
NONE