### PR TITLE
root-signing: Remove status checks from branch protection

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1433,9 +1433,6 @@ repositories:
         requiredApprovingReviewCount: 1
         requireLastPushApproval: true
         restrictDismissals: true
-        statusChecks:
-          - DCO
-          - yamllint
         pushRestrictions:
           - tuf-root-signing-codeowners
           - sigstore-bot


### PR DESCRIPTION
tuf-on-ci (the new tooling for root-signing) commits the online signature without a PR existing: this means status checks are not available for that commit.

This should fix https://github.com/sigstore/root-signing/issues/1349 and enables https://github.com/sigstore/root-signing/issues/1320.

While the status checks here would be nice, we're not really losing that much when we remove dco and yamllint...