### PR TITLE
root-signing: Enable github actions

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1401,6 +1401,8 @@ repositories:
     hasIssues: true
     hasProjects: true
     hasWiki: true
+    pages:
+      buildType: workflow
     vulnerabilityAlerts: false
     visibility: public
     licenseTemplate: ""


### PR DESCRIPTION
This is needed for the internal "preprod" repository and matches how root-signing-staging is setup.

Partially helps with sigstore/root-signing#1351 -- although I am not sure how we tweak the github-pages environment (that is automatically created when pages is enabled)