### PR TITLE
Update the codeql version from ancient to current

### DIFF
--- a/.github/workflows/reusable-scorecard.yml
+++ b/.github/workflows/reusable-scorecard.yml
@@ -68,6 +68,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@896079047b4bb059ba6f150a5d87d47dde99e6e5 # v2.11.6
+        uses: github/codeql-action/upload-sarif@8214744c546c1e5c8f03dde8fab3a7353211988d # v3.26.7
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
* v2.11.6 (the old version comment) is not a codeql release
* The old hash was not a release commit at all 

Apparently in this case dependabot does nothing. Update codeql release to current release commit.
