### PR TITLE
sigstore/repositories: update Python repo maintainers

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -707,13 +707,13 @@ repositories:
     collaborators:
       - username: di
         permission: admin
-      - username: tetsuo-cpp
-        permission: admin
       - username: woodruffw
         permission: admin
-      - username: tnytown
-        permission: triage
       - username: jku
+        permission: maintain
+      - username: DarkaMaul
+        permission: maintain
+      - username: facutuesca
         permission: maintain
     teams: []
     branchesProtection:
@@ -2225,14 +2225,14 @@ repositories:
         permission: admin
       - username: lukehinds
         permission: admin
-      - username: tetsuo-cpp
-        permission: maintain
       - username: woodruffw
         permission: maintain
       - username: jku
         permission: maintain
-      - username: tnytown
-        permission: triage
+      - username: DarkaMaul
+        permission: maintain
+      - username: facutuesca
+        permission: maintain
     teams:
       - name: Core Team
         id: 4563391


### PR DESCRIPTION
This updates the maintainers for `gh-action-sigstore-python` and `sigstore-python` to remove two inactive maintainers (one former ToB, the other not currently working on either repo), and adds two new maintainers who are on my team: @DarkaMaul and @facutuesca.

I've given them both `maintain` permissions, since the repo itself still has two-person controls.