### PR TITLE
add ejahnGithub as rekor-search-ui maintainer

### DIFF
--- a/github-sync/github-data/sigstore/users.yaml
+++ b/github-sync/github-data/sigstore/users.yaml
@@ -164,6 +164,8 @@ users:
   - username: ejahnGithub
     role: member
     teams:
+      - name: codeowners-rekor-search-ui
+        role: maintainer
       - name: codeowners-sigstore-js
         role: maintainer
   - username: erikaheidi


### PR DESCRIPTION
Adds @ejahnGithub as a maintainer for the rekor-search-ui project. Currently, `bdehamer` is the only maintainer for this project.