### PR TITLE
update repo data to reflect archival decisions for two repos

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -447,7 +447,7 @@ repositories:
     allowMergeCommit: true
     allowRebaseMerge: true
     allowSquashMerge: true
-    archived: false
+    archived: true
     autoInit: false
     deleteBranchOnMerge: false
     hasDownloads: true
@@ -1909,7 +1909,7 @@ repositories:
     allowMergeCommit: false
     allowRebaseMerge: true
     allowSquashMerge: true
-    archived: false
+    archived: true
     autoInit: false
     deleteBranchOnMerge: true
     hasDownloads: true


### PR DESCRIPTION
the Sigstore TSC voted to archive sigstore/fish-food and sigstore/sigstore-installer given that they were no longer active projects. This PR updates our data to reflect this decision.

Meeting notes from vote: https://docs.google.com/document/d/1rN_tn2Jf1hd_e6XDLlKg0vmQog3LIxEHfulG50WzgKQ/edit?tab=t.0#heading=h.x9j826571elg