### PR TITLE
update maintainers/triage based on activity

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -1,0 +1,19 @@
+This is a list of prior maintainers whom we sincerely thank for their contributions to the Sigstore project!
+
+- @Dentrax
+- @developer-guy
+- @erkanzileli
+- @sozercan
+- @smythp
+- @jonvnadelberg
+- @jyotsna-penumaka
+- @AndreyKozlov1984
+- @asraa
+- @jvanzyl
+- @devmoran
+- @cstamas
+- @dlorenc
+- @mattmoor
+- @mdunbavan
+- @michael-o
+- @puerco

--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -295,15 +295,7 @@ repositories:
       - sigstore
       - rekor
       - fulcio
-    collaborators:
-      - username: Dentrax
-        permission: maintain
-      - username: developer-guy
-        permission: maintain
-      - username: erkanzileli
-        permission: push
-      - username: sozercan
-        permission: push
+    collaborators: []
     teams:
       - name: cosign-codeowners
         id: 4722092
@@ -417,10 +409,6 @@ repositories:
     collaborators:
       - username: ltagliaferri
         permission: admin
-      - username: smythp
-        permission: maintain
-      - username: jonvnadelberg
-        permission: triage
     teams:
       - name: triage
         id: 5643322
@@ -651,8 +639,6 @@ repositories:
       - sigstore
     collaborators:
       - username: imjasonh
-        permission: maintain
-      - username: jyotsna-penumaka
         permission: maintain
       - username: lkatalin
         permission: maintain
@@ -928,9 +914,7 @@ repositories:
     visibility: public
     licenseTemplate: ""
     topics: []
-    collaborators:
-      - username: AndreyKozlov1984
-        permission: maintain
+    collaborators: []
     webCommitSignoffRequired: true
   - name: model-transparency
     owner: sigstore
@@ -1768,8 +1752,6 @@ repositories:
       - conformance
       - tests
     collaborators:
-      - username: asraa
-        permission: push
       - username: bobcallaway
         permission: admin
       - username: haydentherapper
@@ -2066,9 +2048,7 @@ repositories:
     visibility: public
     licenseTemplate: ""
     topics: []
-    collaborators:
-      - username: jvanzyl
-        permission: admin
+    collaborators: []
     template:
       owner: sigstore
       repository: sigstore-project-template
@@ -2484,9 +2464,7 @@ repositories:
     visibility: public
     licenseTemplate: ""
     topics: []
-    collaborators:
-      - username: devmoran
-        permission: push
+    collaborators: []
     teams:
       - name: codeowners-sigstore-website
         id: 4932390

--- a/github-sync/github-data/sigstore/users.yaml
+++ b/github-sync/github-data/sigstore/users.yaml
@@ -104,9 +104,6 @@ users:
     role: member
   - username: developer-guy
     role: member
-    teams:
-      - name: cosign-codeowners
-        role: member
   - username: di
     role: member
     teams:

--- a/github-sync/github-data/sigstore/users.yaml
+++ b/github-sync/github-data/sigstore/users.yaml
@@ -1,9 +1,6 @@
 users:
   - username: Dentrax
     role: member
-    teams:
-      - name: cosign-codeowners
-        role: member
   - username: SantiagoTorres
     role: admin
     teams:
@@ -23,9 +20,6 @@ users:
         role: member
   - username: asraa
     role: member
-    teams:
-      - name: sigstore-rs-codeowners
-        role: member
   - username: bdehamer
     role: member
     teams:
@@ -106,18 +100,8 @@ users:
         role: member
   - username: cstamas
     role: member
-    teams:
-      - name: codeowners-maven-sigstore
-        role: member
   - username: dekkagaijin
     role: member
-    teams:
-      - name: cosign-codeowners
-        role: member
-      - name: cosign-installer-codeowners
-        role: member
-      - name: sigstore-codeowners
-        role: member
   - username: developer-guy
     role: member
     teams:
@@ -131,10 +115,6 @@ users:
   - username: dlorenc
     role: member
     teams:
-      - name: cosign-installer-codeowners
-        role: maintainer
-      - name: fulcio-codeowners
-        role: maintainer
       - name: helm
         role: maintainer
       - name: policy-controller-codeowners
@@ -297,9 +277,6 @@ users:
         role: maintainer
   - username: jyotsna-penumaka
     role: member
-    teams:
-      - name: sigstore-rs-codeowners
-        role: member
   - username: k4leung4
     role: member
     teams:
@@ -399,21 +376,10 @@ users:
         role: member
   - username: mattmoor
     role: member
-    teams:
-      - name: fulcio-codeowners
-        role: member
-      - name: cosign-codeowners
-        role: member
   - username: mdunbavan
     role: member
-    teams:
-      - name: codeowners-sigstore-website
-        role: member
   - username: michael-o
     role: member
-    teams:
-      - name: codeowners-maven-sigstore
-        role: member
   - username: mihaimaruseac
     role: member
     teams:
@@ -453,9 +419,6 @@ users:
         role: maintainer
   - username: puerco
     role: member
-    teams:
-      - name: triage
-        role: member
   - username: pwelch
     role: member
     teams:


### PR DESCRIPTION
The TSC did a review of contributors/maintainers across a number of Sigstore projects and are proposing a number of changes to maintainer lists to ensure people with merge rights reflect only those who have been recently active. Thanks to everyone for their contributions to Sigstore!

FYI and thanks to @Dentrax @developer-guy @erkanzileli @sozercan @smythp @jonvnadelberg @jyotsna-penumaka @AndreyKozlov1984 @asraa @jvanzyl @devmoran @cstamas @dlorenc @mattmoor @mdunbavan @michael-o @puerco