### PR TITLE
Set up dep-maintainers group to manage dep updates

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -204,8 +204,8 @@ repositories:
       - name: cosign-codeowners
         id: 4722092
         permission: maintain
-      - name: sigstore-release-team
-        id: 4845328
+      - name: dep-maintainers
+        id: 12114078
         permission: maintain
       - name: triage
         id: 5643322
@@ -238,6 +238,10 @@ repositories:
           - attest / verify-attestation test (v1.30.x, air-gap)
         pushRestrictions:
           - cosign-codeowners
+          - dep-maintainers
+        dismissalRestrictions:
+          - cosign-codeowners
+          - dep-maintainers
       - pattern: release-1.13
         enforceAdmins: true
         allowsDeletions: false
@@ -266,6 +270,10 @@ repositories:
           - validate-release-job
         pushRestrictions:
           - cosign-codeowners
+          - dep-maintainers
+        dismissalRestrictions:
+          - cosign-codeowners
+          - dep-maintainers
     webCommitSignoffRequired: true
   - name: cosign-gatekeeper-provider
     owner: sigstore
@@ -511,9 +519,9 @@ repositories:
       - name: fulcio-codeowners
         id: 4721751
         permission: maintain
-      - name: sigstore-release-team
-        id: 4845328
-        permission: push
+      - name: dep-maintainers
+        id: 12114078
+        permission: maintain
       - name: triage
         id: 5643322
         permission: triage
@@ -544,8 +552,10 @@ repositories:
           - CodeQL
         pushRestrictions:
           - fulcio-codeowners
+          - dep-maintainers
         dismissalRestrictions:
           - fulcio-codeowners
+          - dep-maintainers
       - pattern: release-1.0
         enforceAdmins: true
         allowsDeletions: false
@@ -562,8 +572,10 @@ repositories:
           - Analyze (go)
         pushRestrictions:
           - fulcio-codeowners
+          - dep-maintainers
         dismissalRestrictions:
           - fulcio-codeowners
+          - dep-maintainers
     webCommitSignoffRequired: true
   - name: github-sync
     owner: sigstore
@@ -1234,9 +1246,9 @@ repositories:
       - name: rekor-codeowners
         id: 4721448
         permission: maintain
-      - name: sigstore-release-team
-        id: 4845328
-        permission: push
+      - name: dep-maintainers
+        id: 12114078
+        permission: maintain
       - name: triage
         id: 5643322
         permission: triage
@@ -1265,6 +1277,10 @@ repositories:
           - license boilerplate check
         pushRestrictions:
           - rekor-codeowners
+          - dep-maintainers
+        dismissalRestrictions:
+          - rekor-codeowners
+          - dep-maintainers
       - pattern: release-1.0
         enforceAdmins: false
         allowsDeletions: true
@@ -1282,6 +1298,10 @@ repositories:
           - CodeQL
         pushRestrictions:
           - rekor-codeowners
+          - dep-maintainers
+        dismissalRestrictions:
+          - rekor-codeowners
+          - dep-maintainers
     webCommitSignoffRequired: true
   - name: rekor-monitor
     owner: sigstore
@@ -1653,8 +1673,8 @@ repositories:
       - name: sigstore-codeowners
         id: 4722047
         permission: maintain
-      - name: sigstore-release-team
-        id: 4845328
+      - name: dep-maintainers
+        id: 12114078
         permission: maintain
       - name: triage
         id: 5643322
@@ -1678,8 +1698,10 @@ repositories:
           - lint checks
         pushRestrictions:
           - sigstore-codeowners
+          - dep-maintainers
         dismissalRestrictions:
           - sigstore-codeowners
+          - dep-maintainers
     webCommitSignoffRequired: true
   - name: sigstore-blog
     owner: sigstore
@@ -1862,7 +1884,7 @@ repositories:
         allowsForcePushes: false
         requiredLinearHistory: true
         requiredApprovingReviewCount: 1
-        requireCodeOwnerReviews: false
+        requireCodeOwnerReviews: true
         restrictDismissals: true
         requireBranchesUpToDate: false
         dismissStaleReviews: true

--- a/github-sync/github-data/sigstore/users.yaml
+++ b/github-sync/github-data/sigstore/users.yaml
@@ -92,12 +92,14 @@ users:
         role: member
       - name: cosign-installer-codeowners
         role: maintainer
+      - name: dep-maintainers
+        role: member
+      - name: gitsign-codeowners
+        role: member
       - name: helm
         role: maintainer
       - name: sigstore-release-team
         role: maintainer
-      - name: gitsign-codeowners
-        role: member
   - username: cstamas
     role: member
   - username: dekkagaijin


### PR DESCRIPTION
Adds cpanato@ as a member, and add the team as a maintainer for cosign, fulcio, sigstore/sigstore and rekor. Also added dismiss restrictions for these repos.

Any repos that want dep management can add this team.

Misc:

* Require codeowners for sigstore-go
* Removed sigstore-release-team as a maintainer, as this was unused

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
