### PR TITLE
update status checks for sigstore/sigstore

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1695,7 +1695,12 @@ repositories:
           - license boilerplate check
           - Analyze (go)
           - e2e integration tests
-          - lint checks
+          - lint checks (./)
+          - lint checks (pkg/signature/kms/aws)
+          - lint checks (pkg/signature/kms/azure)
+          - lint checks (pkg/signature/kms/cliplugin)
+          - lint checks (pkg/signature/kms/gcp)
+          - lint checks (pkg/signature/kms/hashivault)
         pushRestrictions:
           - sigstore-codeowners
           - dep-maintainers


### PR DESCRIPTION
tests to run linters against the various KMS plugins have recently been added to sigstore/sigstore; this makes them required checks

@haydentherapper  fyi