### PR TITLE
Update dependabot.yml for actions in this repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-      - "/actions"
+      - "/actions/**"
     schedule:
       interval: "daily"
     groups:


### PR DESCRIPTION
dependabot wasn't running because the actions in this repo are in a subdirectory of `/actions`