### PR TITLE
Do not require codeowners where dep-maintainers is used

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -218,7 +218,7 @@ repositories:
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
-        requireCodeOwnerReviews: true
+        requireCodeOwnerReviews: false
         requireLastPushApproval: true
         statusChecks:
           - Check Whitespace
@@ -249,7 +249,7 @@ repositories:
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
-        requireCodeOwnerReviews: true
+        requireCodeOwnerReviews: false
         requireLastPushApproval: true
         statusChecks:
           - Check Whitespace
@@ -533,7 +533,7 @@ repositories:
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
-        requireCodeOwnerReviews: true
+        requireCodeOwnerReviews: false
         restrictDismissals: true
         requireLastPushApproval: true
         statusChecks:
@@ -563,7 +563,7 @@ repositories:
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
-        requireCodeOwnerReviews: true
+        requireCodeOwnerReviews: false
         restrictDismissals: true
         requireLastPushApproval: true
         statusChecks:
@@ -1258,6 +1258,7 @@ repositories:
         allowsDeletions: false
         allowsForcePushes: false
         requiredLinearHistory: true
+        requireCodeOwnerReviews: false
         requireConversationResolution: false
         requireSignedCommits: false
         dismissStaleReviews: true
@@ -1286,6 +1287,7 @@ repositories:
         allowsDeletions: true
         allowsForcePushes: false
         requiredLinearHistory: true
+        requireCodeOwnerReviews: false
         requireConversationResolution: false
         requireSignedCommits: false
         dismissStaleReviews: true
@@ -1687,7 +1689,7 @@ repositories:
         requiredLinearHistory: true
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
-        requireCodeOwnerReviews: true
+        requireCodeOwnerReviews: false
         restrictDismissals: true
         requireLastPushApproval: true
         statusChecks:
@@ -1889,7 +1891,7 @@ repositories:
         allowsForcePushes: false
         requiredLinearHistory: true
         requiredApprovingReviewCount: 1
-        requireCodeOwnerReviews: true
+        requireCodeOwnerReviews: false
         restrictDismissals: true
         requireBranchesUpToDate: false
         dismissStaleReviews: true


### PR DESCRIPTION
Codeowners will still be notified of PRs as per the CODEOWNERS file, but those in the *-codeowners or dep-maintainers teams can still merge without the other being required.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
