### PR TITLE
remove test from required list

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1700,7 +1700,6 @@ repositories:
           - lint checks (./)
           - lint checks (pkg/signature/kms/aws)
           - lint checks (pkg/signature/kms/azure)
-          - lint checks (pkg/signature/kms/cliplugin)
           - lint checks (pkg/signature/kms/gcp)
           - lint checks (pkg/signature/kms/hashivault)
         pushRestrictions:


### PR DESCRIPTION
https://github.com/sigstore/sigstore/pull/1956 removes the cliplugin as a separate gomodule, so this removes the requirement for a corresponding test to run

