### PR TITLE
Add missing restrict dismissal bit for repos

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -220,6 +220,7 @@ repositories:
         requiredApprovingReviewCount: 1
         requireCodeOwnerReviews: false
         requireLastPushApproval: true
+        restrictDismissals: true
         statusChecks:
           - Check Whitespace
           - DCO
@@ -251,6 +252,7 @@ repositories:
         requiredApprovingReviewCount: 1
         requireCodeOwnerReviews: false
         requireLastPushApproval: true
+        restrictDismissals: true
         statusChecks:
           - Check Whitespace
           - DCO
@@ -1266,6 +1268,7 @@ repositories:
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
         requireLastPushApproval: true
+        restrictDismissals: true
         statusChecks:
           - build
           - DCO
@@ -1294,6 +1297,7 @@ repositories:
         requireSignedCommits: false
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
+        restrictDismissals: true
         statusChecks:
           - build
           - DCO
@@ -1459,6 +1463,7 @@ repositories:
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
         requireLastPushApproval: true
+        restrictDismissals: true
         statusChecks: []
         pushRestrictions:
           - rekor-tiles-codeowners


### PR DESCRIPTION
As seen in https://github.com/sigstore/community/actions/runs/13466832138/job/37634278487, there's a diff if this bit is not set.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
