### PR TITLE
Allow automerge for `model-transparency`

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -934,7 +934,7 @@ repositories:
     description: Supply chain security for ML
     homepageUrl: ""
     defaultBranch: main
-    allowAutoMerge: false
+    allowAutoMerge: true
     allowMergeCommit: false
     allowRebaseMerge: true
     allowSquashMerge: true


### PR DESCRIPTION
#### Summary
This is to speed-up merging PRs when reviewer is in a different timezone. No functional change, no changes in who can approve, just making it possible to automatically merge PRs once they got approved.

#### Release Note
NONE

#### Documentation
NONE
