### PR TITLE
add pages for model-transparency

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -964,6 +964,8 @@ repositories:
         permission: push
     pages:
       buildType: workflow
+      branch: main
+      path: /
     branchesProtection:
       - pattern: main
         enforceAdmins: true


### PR DESCRIPTION
There are regularly changes proposed in pulumi runs that appear to want to revert this setting; adding it to quiet pulumi.

```
~ github:index/repository:Repository: (update) 🔒
      [id=model-transparency]
      [urn=urn:pulumi:github-prod::sigstore-github-sync::github:index/repository:Repository::model-transparency]
      [provider=urn:pulumi:github-prod::sigstore-github-sync::pulumi:providers:github::default_6_6_0::6b4fe4fa-33d1-454e-aea1-c3905d0b89f1]
    ~ pages: {
        - source: {
            - branch: "main"
            - path  : "/"
          }
      }
```