### PR TITLE
sigstore: add myself to architecture-doc-team

### DIFF
--- a/github-sync/github-data/sigstore-conformance/repositories.yaml
+++ b/github-sync/github-data/sigstore-conformance/repositories.yaml
@@ -51,8 +51,6 @@ repositories:
     licenseTemplate: ""
     topics: []
     collaborators:
-      - username: tetsuo-cpp
-        permission: maintain
       - username: woodruffw
         permission: maintain
       - username: jku

--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1860,8 +1860,6 @@ repositories:
         permission: push
       - username: loosebazooka
         permission: push
-      - username: tetsuo-cpp
-        permission: admin
       - username: tnytown
         permission: triage
     teams:

--- a/github-sync/github-data/sigstore/users.yaml
+++ b/github-sync/github-data/sigstore/users.yaml
@@ -478,11 +478,6 @@ users:
         role: member
       - name: sigstore-go-codeowners
         role: member
-  - username: tetsuo-cpp
-    role: member
-    teams:
-      - name: sigstore-conformance-codeowners
-        role: member
   - username: TomHennen
     role: member
     teams: []
@@ -516,6 +511,8 @@ users:
       - name: protobuf-specs-codeowners
         role: member
       - name: sigstore-conformance-codeowners
+        role: member
+      - name: architecture-doc-team
         role: member
   - username: yrobla
     role: member


### PR DESCRIPTION
Also removes a former coworker (`@tetsuo-cpp`) from his team/repo assignments, as he's no longer active in Sigstore.

