### PR TITLE
use workflow only to publish GH pages for rekor-search-ui

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -1394,8 +1394,7 @@ repositories:
         id: 5643322
         permission: triage
     pages:
-      branch: main
-      path: /
+      buildType: workflow
       cname: search.sigstore.dev
     branchesProtection:
       - pattern: main


### PR DESCRIPTION
we had the `rekor-search-ui` repo configured to do its own build/deploy step AND also https://github.com/sigstore/rekor-search-ui/actions/workflows/nextjs.yml

depending on which one finished last, we'd either get a correct deployment OR one that just showed the project README