### PR TITLE
sigstore-python: Don't require up-to-date branches

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -2427,7 +2427,7 @@ repositories:
         dismissStaleReviews: true
         requiredApprovingReviewCount: 1
         requireCodeOwnerReviews: true
-        requireBranchesUpToDate: true
+        requireBranchesUpToDate: false
         requireLastPushApproval: true
         statusChecks:
           - DCO


### PR DESCRIPTION
This is "Require branches to be up to date before merging" option in branch protection rules.

It's quite annoying to ask contributors to rebase/merge after the PR has been approved (end then potentially ask again since main HEAD has moved again). I don't think we lose much with this disabled.


@woodruffw unsure if you chose this value originally, let me know if you disagree with this one.