### PR TITLE
add Tekton (Chains) to ecosystem adoption status table

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,6 +90,7 @@ The table below summarizes the state of Sigstore adoption across various ecosyst
 |  Spring + Gradle     | signing + provenance (SLSA)               |   Early WIP          |
 |        Homebrew      | signing + provenance (SLSA)               |   Beta               |
 |   GitHub Actions     | signing + provenance (SLSA)               |         GA           |
+| [Tekton (Chains)](https://github.com/tektoncd/chains) | signing + provenance (SLSA) |         GA           |
 
 Last but certainly not least, Sigstore has publicly hosted [documentation](https://docs.sigstore.dev) that includes an architectural overview and a community-authored [threat model](https://docs.sigstore.dev/threat-model/) and [claimant models](https://github.com/sigstore/community/tree/main/docs/claimantmodel) for the transparency logs it operates. There are also more detailed [architecture documents](https://docs.google.com/document/d/1-OccxmZwkZZItrfOnO3RP8gku6nRbtJpth1mSW3U1Cc/edit#heading=h.ksk0rwk2ti2e) being created to describe the principles behind our signature transparency log, certificate authority, and public-good instances.
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
The ROADMAP.md ecosystem adoption status table lists notable adopters of Sigstore but was missing Tekton Chains, a widely-used supply chain security controller that is a direct consumer of Sigstore's public-good infrastructure (Cosign, Fulcio, and Rekor). This PR adds Tekton Chains as a GA entry to the table.

Resolves #723


#### Release Note

NONE
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->