### PR TITLE
Use lowercase username for ejahngithub

### DIFF
--- a/github-sync/github-data/sigstore/users.yaml
+++ b/github-sync/github-data/sigstore/users.yaml
@@ -148,7 +148,7 @@ users:
     teams:
       - name: codeowners-sigstore-js
         role: maintainer
-  - username: ejahnGithub
+  - username: ejahngithub
     role: member
     teams:
       - name: codeowners-rekor-search-ui


### PR DESCRIPTION
## Context

In #722, the duplicate lowercase `ejahngithub` entry was removed from `users.yaml`, leaving only the mixed-case `ejahnGithub` entry. After that sync ran, I lost `codeowners-sigstore-js` team membership — even though that team is still listed under my (mixed-case) entry. My memberships on `codeowners-rekor-search-ui` and `sigstore-oncall` (also driven by the mixed-case entry) were untouched.

## Root cause

This is a leftover from #280 (June 2023). At the time my entry was added as lowercase `ejahngithub`. #280 added a *second* entry `ejahnGithub` to fix the casing, with the explicit plan to ['do the removal of the old name in a separate PR'](https://github.com/sigstore/community/pull/280#issuecomment-1579162494) — which never landed.

That left Pulumi with **two resources pointing at the same underlying GitHub team membership** on `codeowners-sigstore-js`:
- `ejahngithub-codeowners-sigstore-js`
- `ejahnGithub-codeowners-sigstore-js`

When #722 removed the lowercase YAML entry, Pulumi deleted the `ejahngithub-codeowners-sigstore-js` resource and called GitHub's remove-from-team API — which removed me from the team, even though the `ejahnGithub-codeowners-sigstore-js` resource still declares me as a maintainer. Pulumi doesn't realize the two URNs collapse to the same GitHub-side membership.

Only `codeowners-sigstore-js` was affected because it was the only team that ever had the duplicate-URN setup (the other two teams were added only under the mixed-case entry, after #280).

## Fix

Rename `ejahnGithub` → `ejahngithub` in `users.yaml`. This:
- Deletes `ejahnGithub-codeowners-sigstore-js` (no-op on GitHub — membership already gone).
- Creates a new `ejahngithub-codeowners-sigstore-js` → re-adds me to the team.
- For `codeowners-rekor-search-ui` and `sigstore-oncall`, Pulumi will delete + recreate; net effect is the same membership.

This also aligns with GitHub's canonical lowercase form for the username.