### PR TITLE
Add baszalmstra, wolfv, and jku as sigstore-rust maintainers

### DIFF
--- a/github-sync/github-data/sigstore/repositories.yaml
+++ b/github-sync/github-data/sigstore/repositories.yaml
@@ -2483,7 +2483,10 @@ repositories:
       - package-management
       - sigstore
     collaborators: []
-    teams: []
+    teams:
+      - name: sigstore-rust-codeowners
+        id: 17208082
+        permission: maintain
     branchesProtection:
       - pattern: main
         enforceAdmins: true
@@ -2500,6 +2503,7 @@ repositories:
           - DCO
         pushRestrictions:
           - dep-maintainers
+          - sigstore-rust-codeowners
         dismissalRestrictions:
           - dep-maintainers
     webCommitSignoffRequired: true

--- a/github-sync/github-data/sigstore/users.yaml
+++ b/github-sync/github-data/sigstore/users.yaml
@@ -23,6 +23,11 @@ users:
     teams: []
   - username: asraa
     role: member
+  - username: baszalmstra
+    role: member
+    teams:
+      - name: sigstore-rust-codeowners
+        role: member
   - username: bdehamer
     role: member
     teams:

--- a/github-sync/github-data/sigstore/users.yaml
+++ b/github-sync/github-data/sigstore/users.yaml
@@ -280,6 +280,8 @@ users:
   - username: jku
     role: member
     teams:
+      - name: sigstore-rust-codeowners
+        role: member
       - name: infrastructure-team
         role: member
       - name: tuf-root-signing-staging-codeowners
@@ -535,7 +537,9 @@ users:
         role: member
   - username: wolfv
     role: member
-    teams: []
+    teams:
+      - name: sigstore-rust-codeowners
+        role: member
   - username: wlynch
     role: member
     teams:


### PR DESCRIPTION
#### Summary

Propose @baszalmstra (Bas Zalmstra), @wolfv (Wolf Vollprecht), and @jku (Jussi) as members of the existing `sigstore-rust-codeowners` team.

- Add @baszalmstra as an organization member and add all three users to the codeowners team. Preserve all existing memberships for @wolfv and @jku.
- Grant that team `maintain` access to `sigstore-rust` (the team exists but currently has no repository permissions configured).
- Add the team to the `main` push allowlist so maintainers can merge approved PRs. Existing review requirements and other branch protections remain unchanged.

This proposal is subject to Codeowner/TSC review under MEMBERSHIP.md.

Closes #742.

#### Validation

Parsed the changed YAML with Ruby Psych. Checked that all three users belong to the codeowners team exactly once, existing memberships are preserved, and repository changes are limited to team maintain access and the push allowance. `git diff --check` passed. The team ID was verified through the GitHub API. Pulumi preview is left to CI.

#### Release Note

NONE

#### Documentation

No documentation changes required.